### PR TITLE
Repo: restructuring, manual rewriting

### DIFF
--- a/draft-holmgren-at-repository.md
+++ b/draft-holmgren-at-repository.md
@@ -33,6 +33,7 @@ normative:
   CBOR: RFC8949
   RFC7049: RFC7049
   RFC3986: RFC3986
+  RFC4648: RFC4648
   DID:
     title: "Decentralized Identifiers  (DIDs) v1.0"
     date: July 2022
@@ -258,8 +259,9 @@ To verify the signature, remove the `sig` field and encode the unsigned commit o
 
 ## Records {#records}
 
-TODO: always CBOR object, always has $type matching the collection
-TODO: mention that invalid/corrupt records do not invalidate overall repository
+Records stored within a repository are always objects (or "maps) encoded as CBOR, following the data model and encoding rules described in {{data-model}}. Each record must include a top-level field named `$type` with a string value matching the collection type name (NSID) of the path that the record is stored at.
+
+Invalid or corrupt data in individual records should not impact processing of the overall repository data structure, or the processing of other valid records in the same repository.
 
 # Merkle Search Tree {#mst}
 
@@ -445,23 +447,46 @@ This document has no IANA actions.
 
 # Data Model {#data-model}
 
-TODO: context about determinism and JSON/CBOR mapping (especially for record data)
+All components of the repository data structure conform to a limited data model and defined encoding rules. CBOR encoding (following the rules in {{cbor-encoding}}) is used for consistent hashing of data. A JSON encoding is also defined for record data, with lossless mapping between the CBOR and JSON encodings.
+
+The data model includes the following types:
+
+- **null values**: represented as 'null' in JSON, and the null special value (major 7) in CBOR
+- **boolean values**: represented as 'true' / 'false' in JSON, and special values (major 7) in CBOR
+- **integer values**: with signed 64-bit precision. Represented as numbers in JSON, and Integers (majors 0,1) in CBOR
+- **string values**: represented as strings in JSON, and UTF-8 Strings (major 3) in CBOR
+- **byte string values**: represented with a special object type in JSON (see {{json-encoding}}) and as a Byte String (major 2) in CBOR
+- **content hash links**: as described in {{cid-link}}, represented as a special object type in JSON, and as a tag 42 byte string in CBOR
+- **arrays**: represented as arrays in JSON, and Arrays (major 4) in CBOR
+- **objects**: represented as objects in JSON, and Maps (major 5) in CBOR. Object keys must always be strings.
+
+As a best practice to ensure compatibility with programming languages which represent all numbers in floating point by default, integer values should be limited to 53 bits of precision when possible.
 
 ## Content Identifier (CID) Hashes {#cid-link}
 
-TODO: talk about string encoding and JSON encoding (in addition to bytes)
+References to data objects by hash occur throughout the repository data structure. They also occur between records at the application layer. A consistent way of computing and encoding these hash links, named Content Identifier (CID), is described here. In addition to "CID Links" between objects, it is possible to represent CIDs as regular hash strings (without the "link" data model semantics). It is also possible to represent the hash of arbitrary binary data as a CID.
 
-For interoperability purposes, hash links between repository objects are encoded using a specific format within the CBOR structure. SHA-256 hash links are represented as CBOR byte strings under tag 42, with the byte string containing the 32-byte hash value prefixed by the fixed byte sequence `0x01711220`.
+Data objects to be referenced are first encoded as CBOR. The encoded bytes are hashed using SHA-256, resulting in a 32-byte binary hash value. The hash bytes are prefixed with the 4-byte prefix value `0x01711220`, resulting in a 36-byte binary CID.
 
-Hash links that point to arbitrary binary data instead of other repository objects should be encoded similarly though prefixed by the fixed byte sequence `0x01551220`.
+This fixed prefix value is used for historical reasons, and indicates that the referenced data is CBOR encoded. If using a CID to reference arbitrary binary data, use the fixed 4-byte value `0x01551220` instead.
 
-The four prefix bytes encode (in order): a version byte `0x01`; a codec identifier byte (`0x71` for repository objects encoded with deterministic CBOR; `0x55` for arbitrary raw binary data); a hash-algorithm identifier byte `0x12` indicating SHA-256; and a hash-length byte `0x20` indicating 32 bytes. The 32-byte SHA-256 digest follows.
+When representing a CID link in CBOR, the binary CID value has an additional null byte (0x00) prepended, then the 37 bytes are stored as a byte string using the IANA-registered CBOR Tag 42.
+
+When representing a CID value as a string, the 36-byte binary CID value is encoded using {{RFC4648}} lower-case base32, and then the ASCII character 'b' (lower-case B) is prefixed. This results in a 59 character lower-case ASCII string.
+
+When referencing a CID link in JSON, first compute the string representation as described above. The link is then represented as a JSON object with a single key (`$link`) and the value being the string value. For example:
+
+~~~json
+{
+  "$link": "bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a"
+}
+~~~
 
 ## CBOR Encoding {#cbor-encoding}
 
 Repository content requires consistent binary representation across all implementations to ensure identical content hashes and verifiable integrity. All records, MST nodes, and commits must be encoded using Deterministically Encoded CBOR as specified in {{Section 4.2 of CBOR}}, with map key ordering following the original specification in {{Section 3.9 of RFC7049}} for historical compatibility.
 
-The deterministic encoding rules that apply in this specification are:
+The encoding rules that apply in this document are:
 
 - Integers are encoded in their shortest form
 - All arrays, maps, and strings are encoded with explicit lengths; CBOR's indefinite-length encoding is not used
@@ -473,8 +498,17 @@ The encoding rules described here are compatible with similar deterministic-CBOR
 
 ## JSON Encoding {#json-encoding}
 
-TODO: bytes (base64)
-TODO: cid-link
+The JSON representation of records or other repository data objects does not need to have a deterministic binary encoding.
+
+Byte strings are represented in JSON using a special object type. The binary data is first string encoded in base64, as described in {{RFC4648}} Section 4. This variant is not URL-safe, and `=` padding is optional. The special JSON object has a single string key `$bytes`, and the value is the base64 encoded data. For example:
+
+~~~json
+{
+  "$bytes": "nFERjvLLiw9qm45JrqH9QTzyC2Lu1Xb4ne6+sBrCzI0"
+}
+~~~
+
+Content hash links (CID links) are represented as special objects as described in {{cid-link}}.
 
 # Cryptography {#crypto}
 

--- a/draft-holmgren-at-repository.md
+++ b/draft-holmgren-at-repository.md
@@ -145,7 +145,7 @@ Records within a repository are identified by a non-empty case-sensitive ASCII s
 
 A path string is the combination of a collection type name and a record key, joined by a single forward slash character: `<collection>/<record-key>`. A path MUST consist of exactly two segments separated by `/`, with no leading or trailing slash.
 
-Collection names use the Namespaced Identifier (NSID) syntax described in an appendix. They have a prefix-ordered namespace structure, which means that records of the same collection are stored adjacently, and that collections under the same authority are grouped together.
+Collection names use the Namespaced Identifier (NSID) syntax described in {{nsid}}. They have a prefix-ordered namespace structure, which means that records of the same collection are stored adjacently, and that collections under the same authority are grouped together.
 
 Record keys uniquely identify records within a collection. Record keys are case-sensitive and MUST satisfy the following syntax:
 

--- a/draft-holmgren-at-repository.md
+++ b/draft-holmgren-at-repository.md
@@ -1,5 +1,5 @@
 ---
-title: "Authenticated Transfer Repository"
+title: "Authenticated Transfer: Repository"
 abbrev: "AT Repo"
 category: std
 
@@ -11,10 +11,13 @@ date:
 consensus:
 v: 0
 area: "Applications and Real-Time Area"
-workgroup:
+workgroup: "Authenticated Transfer"
 keyword:
 venue:
-  github: "bluesky-social/ietf-drafts"
+  group: "Authenticated Transfer"
+  type: "Working Group"
+  mail: "atp@ietf.org"
+  github: "ietf-wg-atp/drafts"
 
 author:
  -
@@ -92,7 +95,7 @@ normative:
         organization: Standards for Efficient Cryptography Group
 
 informative:
-  MST:
+  MSTPAPER:
     title: "Merkle Search Trees: Efficient State-Based CRDTs in Open Networks"
     date: October 2019
     target: https://inria.hal.science/hal-02303490/document
@@ -110,6 +113,16 @@ informative:
         organization: Bluesky Social
       -
         fullname: Daniel Holmgren
+        organization: Bluesky Social
+  AT-SYNC:
+    title: "Authenticated Transfer Protocol: Synchronization"
+    date: draft-holmgren-at-synchronization
+    author:
+      -
+        fullname: Daniel Holmgren
+        organization: Bluesky Social
+      -
+        fullname: Bryan Newbold
         organization: Bluesky Social
   DIDWEB:
     title: "did:web Method Specification (Draft)"
@@ -158,7 +171,7 @@ This document specifically deals with the repository structure and format. Overa
 
 --- middle
 
-# Introduction {#user-id}
+# Introduction {#intro}
 
 The Authenticated Transfer (AT) repository addresses the challenges of building decentralized applications that require consistent data replication across distributed multi-party infrastructure. Traditional web platforms maintain user data at a single network location, creating vendor lock-in and limiting user agency over their digital identity and published content.
 
@@ -294,6 +307,8 @@ Implementations SHOULD reject commits whose `rev` corresponds to a future timest
 The MST structure is deterministically reproducible from any given key-value mapping, where keys are non-empty byte strings and values are hash link references to records. This deterministic construction ensures that identical input sets always produce the same root hash regardless of insertion order.
 
 The tree's structural organization depends solely on the keys present, not on the record values they reference. When a record value changes, the new content hash propagates up through the tree nodes to the root, but the tree's shape and node organization remain unchanged.
+
+The MST data structure was first published in {{MSTPAPER}}.
 
 ## Tree Structure {#mst-structure}
 
@@ -472,8 +487,8 @@ Following the header, each repository block is serialized by concatenating:
 3. The CBOR-encoded block data
 
 ~~~aasvg
-|------- Header -------| |------------------ Data ------------------|
-[ int | Header block ] [ int | hash | block ] [ int | hash | block ] …
+|------- Header -------| |--------------------- Data --------------------|
+ [ int | header block ]   [ int | hash | block ] [ int | hash | block ] …
 ~~~
 {: #f-serialization title="Repo Serialization Layout"}
 

--- a/draft-holmgren-at-repository.md
+++ b/draft-holmgren-at-repository.md
@@ -34,52 +34,6 @@ normative:
   RFC7049: RFC7049
   RFC3986: RFC3986
   RFC4648: RFC4648
-  DID:
-    title: "Decentralized Identifiers  (DIDs) v1.0"
-    date: July 2022
-    target: https://www.w3.org/TR/2022/REC-did-core-20220719/
-    author:
-      -
-        fullname: Manu Sporny
-        organization: Digital Bazaar
-      -
-        fullname: Dave Longley
-        organization: Digital Bazaar
-      -
-        fullname: Markus Sabadello
-        organization: Danube Tech
-      -
-        fullname: Drummond Reed
-        organization: Evernym/Avast
-      -
-        fullname: Orie Steele
-        organization: Transmute
-      -
-        fullname: Christopher Allen
-        organization: Blockchain Commons
-  CONTROLLEDID:
-    title: "Controlled Identifiers v1.0"
-    date: May 2025
-    target: https://www.w3.org/TR/2025/REC-cid-1.0-20250515/
-    author:
-      -
-        fullname: Dave Longley
-        organization: Digital Bazaar
-      -
-        fullname: Manu Sporny
-        organization: Digital Bazaar
-      -
-        fullname: Markus Sabadello
-        organization: Danube Tech
-      -
-        fullname: Drummond Reed
-        organization: Evernym/Avast
-      -
-        fullname: Orie Steele
-        organization: Transmute
-      -
-        fullname: Christopher Allen
-        organization: Blockchain Commons
   WEBASSEMBLY:
     title: WebAssembly Core Specification
     date: March 2026
@@ -124,37 +78,6 @@ informative:
         organization: Bluesky Social
       -
         fullname: Bryan Newbold
-        organization: Bluesky Social
-  DIDWEB:
-    title: "did:web Method Specification (Draft)"
-    date: July 2024
-    target: https://w3c-ccg.github.io/did-method-web/
-    author:
-      -
-        fullname: Christian Gribneau
-        organization: Ology Newswire, Inc.
-      -
-        fullname: Michael Prorock
-        organization: mesur.io
-      -
-        fullname: Orie Steele
-        organization: Transmute
-      -
-        fullname: Oliver Terbu
-        organization: Consensys
-      -
-        fullname: Mike Xu
-        organization: Consensys
-      -
-        fullname: Dmitri Zagidulin
-        organization: Digital Bazaar
-  DIDPLC:
-    title: "did:plc Method Specification v0.1"
-    date: May 2023
-    target: https://web.plc.directory/spec/v0.1/did-plc
-    author:
-      -
-        fullname: Daniel Holmgren
         organization: Bluesky Social
   DASL-CAR:
     title: "DASL: Content Addressable aRchives (CAR)"

--- a/draft-holmgren-at-repository.md
+++ b/draft-holmgren-at-repository.md
@@ -89,7 +89,7 @@ informative:
 
 --- abstract
 
-This document specifies a repository data structure for storage and and transfer of public user data records as part of the Authenticated Transfer Protocol (ATP). It describes encoding formats for both individual data records and entire repositories. The repository data structure is content-addressable and cryptographically authenticated.
+This document specifies a repository data structure for storage and transfer of public user data records as part of the Authenticated Transfer Protocol (ATP). It describes encoding formats for both individual data records and entire repositories. The repository data structure is content-addressable and cryptographically authenticated.
 
 --- middle
 
@@ -97,9 +97,9 @@ This document specifies a repository data structure for storage and and transfer
 
 The Authenticated Transfer Protocol (ATP) enables the creation of decentralized networks for publication of self-certifying data. An introduction to the overall protocol architecture is given in {{AT-ARCH}}.
 
-User accounts publish structured data records to the network by including them in their public repository. Records within a repository are identified by a unique path and current content version (hash). Records can be created, updated, and deleted at any time. Repositories contain the complete set of current records for the account, and does not include or reveal the existence of previous content.
+User accounts publish structured data records to the network by including them in their public repository. Records within a repository are identified by a unique path and current content version (hash). Records can be created, updated, and deleted at any time. Repositories contain the complete set of current records for the account, and do not include or reveal the existence of previous content.
 
-The repository structure includes the account's persistent identifier, and the overall repository structure is cryptographically signed. The authenticitiy of the entire repository can be verified by resolving the account identifier to the current public key. Data records are not signed individually. Details of account identifier systems and their resolution process are out of scope for this document.
+The repository structure includes the account's persistent identifier, and the overall repository structure is cryptographically signed. The authenticity of the entire repository can be verified by resolving the account identifier to the current public key. Data records are not signed individually. Details of account identifier systems and their resolution process are out of scope for this document.
 
 Large binary data such as images and media files are not stored directly within repositories. Instead, such data is stored externally and referenced in records by a hash link.
 
@@ -127,7 +127,7 @@ This document does not include details or recommendations on account identifier 
 
 Repository commits include a revision field (`rev`) which acts as a logical clock for updates to the repository over time. The revision string is a Timestamp Identifier (TID) as described in {{tid}}.
 
-Revisions may be used when comparing two versions of a repository to determine which is more recent. This is particularly relevant when synchronizing repository indirectly, or from multiple sources over time.
+Revisions may be used when comparing two versions of a repository to determine which is more recent. This is particularly relevant when synchronizing repositories indirectly, or from multiple sources over time.
 
 If a commit TID value corresponds to a timestamp in the future (beyond a short period to accommodate clock drift) the commit SHOULD be ignored. This is to ensure that a newly published commit (with a TID corresponding to the current time) will reliably be accepted as current by the entire network.
 
@@ -141,11 +141,11 @@ Repository contents are encoded using deterministic CBOR serialization and organ
 
 ## Record Paths {#repo-path}
 
-Records within a repository are identified by a non-empty case-sensitive ASCII string called the "path". Records are stored sorted lexigraphically by path, and the efficiency of some repository operations is impacted by sort order.
+Records within a repository are identified by a non-empty case-sensitive ASCII string called the "path". Records are stored sorted lexicographically by path, and the efficiency of some repository operations is impacted by sort order.
 
 A path string is the combination of a collection type name and a record key, joined by a single forward slash character: `<collection>/<record-key>`. A path MUST consist of exactly two segments separated by `/`, with no leading or trailing slash.
 
-Collection names use the Namespaced Identifier (NSID) syntax described in an appendix. They have a prefix-ordered namespace structure, which means that that records of the same collection are stored adjacently, and that collections under the same authority are grouped together.
+Collection names use the Namespaced Identifier (NSID) syntax described in an appendix. They have a prefix-ordered namespace structure, which means that records of the same collection are stored adjacently, and that collections under the same authority are grouped together.
 
 Record keys uniquely identify records within a collection. Record keys are case-sensitive and MUST satisfy the following syntax:
 
@@ -153,7 +153,7 @@ Record keys uniquely identify records within a collection. Record keys are case-
 - Length between 1 and 512 characters (inclusive)
 - The literal values `.` and `..` are prohibited
 
-The syntax of record keys may be constrained further on a per-collection basis at the application layer. A common choice is to use the Timestamp Identifier {{tid}} syntax, which results in lexigraphic sorting by time within a collection. This means that "new" records are all grouped together within a given collection.
+The syntax of record keys may be constrained further on a per-collection basis at the application layer. A common choice is to use the Timestamp Identifier {{tid}} syntax, which results in lexicographic sorting by time within a collection. This means that "new" records are all grouped together within a given collection.
 
 Note that both the NSID and record key string syntaxes are valid path components as defined in Section 3.3 of {{RFC3986}}. It is important to maintain this property.
 
@@ -182,7 +182,7 @@ To verify the signature, remove the `sig` field and encode the unsigned commit o
 
 ## Records {#records}
 
-Records stored within a repository are always objects (or "maps) encoded as CBOR, following the data model and encoding rules described in {{data-model}}. Each record must include a top-level field named `$type` with a string value matching the collection type name (NSID) of the path that the record is stored at.
+Records stored within a repository are always objects (or "maps") encoded as CBOR, following the data model and encoding rules described in {{data-model}}. Each record must include a top-level field named `$type` with a string value matching the collection type name (NSID) of the path that the record is stored at.
 
 Invalid or corrupt data in individual records should not impact processing of the overall repository data structure, or the processing of other valid records in the same repository.
 

--- a/draft-holmgren-at-repository.md
+++ b/draft-holmgren-at-repository.md
@@ -185,126 +185,85 @@ This document describes version `3` of the repository format.
 
 # Repository Semantics {#repo-semantics}
 
-Records are discrete units of user data, each CBOR-encoded and identified by a unique key within the repository. The repository is schema-agnostic and provides the foundational layer for higher-level data models and application semantics.
+Records within a repository are discrete units of structured data, identified by a unique path and versioned by content hash. Records conform to a generic data model, but the content, schema, and semantics of record is varied and application-specific. Records are grouped by type under "collections".
 
-Repositories support individual record operations as well as batch writes that group multiple operations under a single commit, or signed mutation, to the repository. Implementations should apply practical limits on batch sizes to support efficient processing and distribution of repository changes.
+The current state of a repository is summarized in a signed "commit". Any change to the contents of the repository updates the current commit. Commits for an individual account's repository are serialized using a monotonically-increasing "revision" identifier.
 
-# Repository Paths and Record Keys {#repo-paths}
+Updates to repositories may include operations on multiple records in a batch mutation that results in a single signed commit. Implementations should apply practical limits on batch sizes to support efficient processing and distribution of repository changes.
 
-Records within a repository are identified by a non-empty ASCII byte string composed of a collection identifier and a record key. This section specifies the syntax for collections, record keys, and the combined path.
+## Account Identifiers {#account-ids}
 
-## Collection Identifiers (NSIDs) {#collections}
+Repository commit objects ({{commits}}) contain a persistent account identifier, which indicates the publisher of the repository. This account identifier can be resolved to obtain the current cryptographic public keys for the account, and those keys can be used to verify the authenticity of the repository and the records it contains.
 
-Collections are identified by a Namespaced Identifier (NSID): an ASCII string in reverse domain-name order followed by an additional name segment. The portion preceding the final segment is the **domain authority**; the final segment is the **name**.
+The keys associated with an account may be rotated over time. The most recent commit must always be verifiable using the currently resolvable signing key. When rotating signing keys, a new repository commit must be created, even if the contents and structure of the repository remain unchanged.
 
-NSIDs MUST conform to the following syntax:
+This document does not include details or recommendations on account identifier systems.
 
-- Overall:
-    - MUST contain only ASCII characters
-    - MUST separate the domain authority and the name by an ASCII period (`.`)
-    - MUST contain at least three segments
-    - MUST be at most 317 characters in total length
-- Domain authority:
-    - Composed of segments separated by ASCII periods (`.`)
-    - At most 253 characters in total (including periods), and at least two segments
-    - Each segment MUST contain at least 1 and at most 63 characters
-    - The allowed characters are ASCII letters (`A-Z`, `a-z`), digits (`0-9`), and hyphens (`-`)
-    - Segments MUST NOT start or end with a hyphen
-    - The first segment (the top-level domain) MUST NOT start with a digit
-    - The domain authority is not case-sensitive and SHOULD be normalized to lowercase
-- Name:
-    - MUST contain at least 1 and at most 63 characters
-    - The allowed characters are ASCII letters and digits only (`A-Z`, `a-z`, `0-9`)
-    - Hyphens are not allowed
-    - MUST NOT start with a digit
-    - Case-sensitive; implementations MUST NOT normalize case
+## Revisions {#revs}
 
-## Record Keys {#record-keys}
+Repository commits include a revision field (`rev`) which acts as a logical clock for updates to the repository over time. The revision string is a Timestamp Identifier (TID) as described in {{tid}}.
 
-A record key uniquely identifies a record within a collection. Record keys MUST satisfy the following syntax:
+Revisions may be used when comparing two versions of a repository to determine which is more recent. This is particularly relevant when synchronizing repository indirectly, or from multiple sources over time.
 
-- Length between 1 and 512 characters
-- Allowed characters are ASCII alphanumerics (`A-Z`, `a-z`, `0-9`), period (`.`), hyphen (`-`), underscore (`_`), colon (`:`), and tilde (`~`)
-- Case-sensitive
-- The literal values `.` and `..` are not valid record keys
-- MUST be a valid path component as defined in Section 3.3 of {{RFC3986}} (the character set above already satisfies this)
-
-This specification does not constrain which record-key scheme is used. In practice, deployments most commonly use Timestamp Identifiers ({{tids}}) for record keys to obtain temporal locality in the tree.
-
-## Repository Paths {#paths}
-
-A repository path is the combination of a collection identifier and a record key joined by a single forward slash: `<collection>/<record-key>`
-
-A path MUST consist of exactly two segments separated by `/`, with no leading or trailing slash. The combined path string is the byte string used as the MST key.
-
-By convention, records sharing a collection identifier sort adjacently within the repository. Repository efficiency, especially when producing cryptographic proofs for a subset of records, benefits from grouping related records around lexicographically similar keys. This grouping allows for structural sharing within the repository data structure and reduces cryptographic proof sizes.
+If a commit TID value corresponds to a timestamp in the future (beyond a short period to accommodate clock drift) the commit SHOULD be ignored. This is to ensure that a newly published commit (with a TID corresponding to the current time) will reliably be accepted as current by the entire network.
 
 # Repository Structure {#repo-structure}
 
-AT repositories are organized as a [Merkle Search Tree](https://inria.hal.science/hal-02303490/document) ({{MST}}) with a cryptographically signed commit referencing the tree root.
+Repositories are structured as a Merkle Search Tree ({{mst}}) with a cryptographically signed commit object referencing the tree root.
 
-The MST provides several fundamental properties for repository operations. As a content-addressed structure, it enables efficient verification of data. The MST maintains lexicographic key ordering, enabling structural sharing of intermediate tree nodes for related records. It is probabilistically self-balancing, offering consistent performance characteristics. Additionally the MST exhibits unicity, meaning that any given set of keys and values will always produce the same tree structure and root hash regardless of insertion order.
+The MST structure provides several fundamental properties for repository operations. As a content-addressed structure, it enables efficient verification of data. The MST maintains lexicographic key ordering, enabling structural sharing of intermediate tree nodes for related records. It is probabilistically self-balancing, offering consistent performance characteristics. Additionally the MST exhibits unicity, meaning that any given set of keys and values will always produce the same tree structure and root hash regardless of insertion order.
 
-Repository contents are encoded using deterministic CBOR serialization and organized as a directed acyclic graph where data objects reference each other through content hashes. These hash-identified data objects, referred to as "blocks," include three distinct types: commit objects, MST internal nodes, and user records.
+Repository contents are encoded using deterministic CBOR serialization and organized as a directed acyclic graph where data objects reference each other through content hashes. These hash-identified data objects, referred to as "blocks," include three distinct types: commit objects, MST internal nodes, and data records.
 
-Large binary data such as images and media files are not stored directly within repositories. Instead, such data is stored externally and referenced in records by a hash link.
+## Record Paths {#repo-path}
 
-# Account Identifiers {#account-ids}
+Records within a repository are identified by a non-empty case-sensitive ASCII string called the "path". Records are stored sorted lexigraphically by path, and the efficiency of some repository operations is impacted by sort order.
 
-Repository authority is established through a resolvable account identifier specified in the repository commit ({{commits}}). AT currently employs Decentralized Identifiers (DIDs) as defined in {{DID}} for this purpose.
+A path string is the combination of a collection type name and a record key, joined by a single forward slash character: `<collection>/<record-key>`. A path MUST consist of exactly two segments separated by `/`, with no leading or trailing slash.
 
-DIDs are globally unique identifiers that resolve to DID Documents containing cryptographic key material and other metadata associated with the identifier. Resolution enables independent verification of repository commits without dependence on centralized authorities.
+Collection names use the Namespaced Identifier (NSID) syntax described in an appendix. They have a prefix-ordered namespace structure, which means that that records of the same collection are stored adjacently, and that collections under the same authority are grouped together.
 
-Each repository MUST reference exactly one account identifier, and each account identifier MAY be associated with at most one AT repository.
+Record keys uniquely identify records within a collection. Record keys are case-sensitive and MUST satisfy the following syntax:
 
-The signing key for repository commits is specified within the DID document's `verificationMethod` array. The key entry must have an `id` field ending in `#atproto`. When multiple possible verification methods are present, implementations must use the first valid entry and ignore subsequent ones. The public key must be encoded using the `publicKeyMultibase` format as specified in {{CONTROLLEDID}}. The signing key must use one of the signing algorithms described in {{sig-curves}}.
+- Allowed characters are ASCII alphanumerics (`A-Z`, `a-z`, `0-9`), period (`.`), hyphen (`-`), underscore (`_`), colon (`:`), and tilde (`~`)
+- Length between 1 and 512 characters (inclusive)
+- The literal values `.` and `..` are prohibited
 
-Resolution MAY return supplementary information beyond the signing key, including canonical repository hosting locations, alternative account identifiers, or relevant service endpoints.
+The syntax of record keys may be constrained further on a per-collection basis at the application layer. A common choice is to use the Timestamp Identifier {{tid}} syntax, which results in lexigraphic sorting by time within a collection. This means that "new" records are all grouped together within a given collection.
 
-To ensure interoperability, AT currently restricts support to specific DID methods: `did:web` and `did:plc`. The resolution mechanisms and specifications for these methods are described in {{DIDWEB}} and {{DIDPLC}}.
+Note that both the NSID and record key string syntaxes are valid path components as defined in Section 3.3 of {{RFC3986}}. It is important to maintain this property.
 
-# Commit Objects {#commits}
+## Commit Objects {#commits}
 
-Commit objects serve as the authoritative root of each repository, establishing cryptographic ownership and providing a verifiable reference to the state of a repository at a particular point in time. Each commit is digitally signed by the repository owner and contains metadata necessary for verification.
+Commit objects serve as the authoritative root of each repository, establishing cryptographic ownership and providing a verifiable reference to the state of a repository at a particular point in time. Each commit is digitally signed by the repository account owner and contains metadata necessary for verification.
 
 A commit object contains the following data fields:
 
 - **`did`** (string, required): The resolvable account identifier associated with the repository as described in {{account-ids}}
 - **`version`** (integer, required): Repository format version, fixed value of **`3`** for the current specification
-- **`data`** (hash link, required): Hash pointer to the root of the repository’s MST structure
-- **`rev`** (string, required): Repository revision identifier that functions as a logical clock and must increase monotonically (see {{revs}}).
-- **`prev`** (hash link, nullable): Optional pointer to the previous commit object in the repository's history chain. While included for backward compatibility with version 2 repositories, this field is typically `null` in version 3 implementations
+- **`data`** (cid-link, required): Hash pointer to the root of the repository’s MST structure
+- **`rev`** (string, required): Repository revision identifier that functions as a logical clock and must increase monotonically (see {{revs}}). Syntax MUST match {{tid}}.
+- **`prev`** (cid-link, nullable): Optional pointer to the previous commit object in the repository's history chain. While included for backward compatibility with version 2 repositories, this field is typically `null` in version 3 implementations
 - **`sig`** (byte array, required): Cryptographic signature over the commit contents.
 
-Commit signature generation and verification procedures are detailed in {{sig-gen}}.
+Commit objects are signed by the key declared by the repository owner’s resolvable identifier. Neither the signature nor the signed commit object contains information about the curve type or specific public key used for signing. This information must be obtained by resolving the account identifier as described in {{account-ids}}.
 
-# Repository Revisions {#revs}
+The procedure for signing commit objects:
 
-Each repository maintains a `rev` field (short for “revision”) that functions as a logical clock for the progression of the contents of the repository over time. The revision value is a short string value that must increase lexicographically with each new commit.
+1. Encode the unsigned commit object (with `sig` field entirely absent) as CBOR
+2. Sign the encoded bytes as described in {{crypto}}
+3. Include the signature bytes in the `sig` field
 
-Revisions may be used when comparing two repositories, especially when obtained from a non-canonical host, to determine which is more recent.
+To verify the signature, remove the `sig` field and encode the unsigned commit object as CBOR. Then verify the signature against those encoded bytes.
 
-## Timestamp Identifier Format {#tids}
+## Records {#records}
 
-The recommended mechanism for generating revision values is the Timestamp Identifier (TID) format.
+TODO: always CBOR object, always has $type matching the collection
+TODO: mention that invalid/corrupt records do not invalidate overall repository
 
-TIDs provide a standardized revision format with the following properties:
+# Merkle Search Tree {#mst}
 
-- 64-bit integer with big-endian byte ordering
-- Base32-sortable encoding using characters `234567abcdefghijklmnopqrstuvwxyz`
-- Fixed 13-character length with no padding (integer zero encodes as `2222222222222`)
-
-The layout of the 64-bit integer is:
-
-- The top bit is always 0
-- The next 53 bits represent microseconds since the UNIX epoch. 53 bits is chosen as the maximum safe integer precision in a 64-bit floating point number, as used by Javascript.
-- The final 10 bits are a random "clock identifier."
-
-Implementations SHOULD reject commits whose `rev` corresponds to a future timestamp, allowing for a clock-drift tolerance window.
-
-# MST Construction {#mst}
-
-The MST structure is deterministically reproducible from any given key-value mapping, where keys are non-empty byte strings and values are hash link references to records. This deterministic construction ensures that identical input sets always produce the same root hash regardless of insertion order.
+The Merkle Search Tree (MST) structure is deterministically reproducible from any given key-value mapping, where keys are non-empty byte strings (corresponding to a path) and values are hash link references to records. This deterministic construction ensures that identical input sets always produce the same root hash regardless of insertion order.
 
 The tree's structural organization depends solely on the keys present, not on the record values they reference. When a record value changes, the new content hash propagates up through the tree nodes to the root, but the tree's shape and node organization remain unchanged.
 
@@ -380,7 +339,7 @@ MST nodes contain the following fields:
     - `v` (hash link, required): Reference to the record data for this entry
     - `t` (hash link, nullable): Reference to a subtree node at a lower layer containing keys that sort after this entry's key but before the next entry's key in the current node
 
-Hash references appearing within an MST node — the `l` and `t` subtree links, and the `v` record link — MUST use the constrained content-hash format defined in {{cbor}}. 
+Hash references appearing within an MST node — the `l` and `t` subtree links, and the `v` record link — MUST use the constrained content-hash format defined in {{cbor-encoding}}.
 
 ## MST Node example {#mst-node-example}
 
@@ -393,81 +352,33 @@ The following example shows an MST node at layer 1 containing two subtree pointe
 
 This node would be encoded as follows:
 
-~~~json
+~~~
 {
-	l: 0x01711220643b9326...
-	e: [
-		{
-			p: 0,
-			k: "key7",
-			v: 0x017112202d9aa87e...
-			t: 0x0171122047e2886f...
-		},
-		{
-			p: 3,
-			k: "10",
-			v: 0x0171122010b6da2c...
-			t: null
-		}
-	]
+  l: 0x01711220643b9326...
+  e: [
+    {
+      p: 0,
+      k: "key7",
+      v: 0x017112202d9aa87e...
+      t: 0x0171122047e2886f...
+    },
+    {
+      p: 3,
+      k: "10",
+      v: 0x0171122010b6da2c...
+      t: null
+    }
+  ]
 }
 ~~~
-
-# Commit Signatures {#signatures}
-
-Commit objects are signed by the key declared by the repository owner’s resolvable identifier. Neither the signature nor the signed commit object contains information about the curve type or specific public key used for signing. This information must be obtained by resolving the repository's DID as specified in {{account-ids}}.
-
-The most recent commit must always be verifiable using the currently resolvable signing key. When rotating signing keys, a new repository commit must be created, even if the contents and structure of the repository remain unchanged.
-
-## Signature Generation {#sig-gen}
-
-To generate a commit signature:
-
-1. Populate all commit data fields except the `sig` field
-2. Serialize the unsigned commit using deterministic CBOR encoding (see {{cbor}})
-3. Compute the SHA-256 hash of the serialized bytes
-4. Sign the hash using the current signing key associated with the repository's DID
-5. Format the signature as a concatenation of the 32-byte `r` and 32-byte `s` values
-6. Add the resulting 64-byte signature to the commit object as the `sig` field
-
-## Supported Curves {#sig-curves}
-
-AT implementations must support both of the following elliptic curves and signature algorithms:
-
-- NIST P-256 (also known as secp256r1 or p256) {{SEC2}}
-- secp256k1 (also known as k256) {{SEC2}}
-
-## Signature Canonicalization {#sig-canonicalization}
-
-ECDSA signatures exhibit malleability, allowing transformation into distinct but equally valid signatures without access to the private key or original data. While the security impact is limited, signature malleability could enable broadcast of multiple valid versions of the same repository commit with different hashes, potentially causing consumer confusion.
-
-To prevent such scenarios, AT requires all ECDSA signatures to be canonicalized in low-S form. Specifically, the `s` component of the signature must satisfy `s ≤ n/2`, where `n` is the order of the curve's base point.
-
-# Deterministic CBOR Encoding {#cbor}
-
-Repository content requires consistent binary representation across all implementations to ensure identical content hashes and verifiable integrity. All records, MST nodes, and commits must be encoded using Deterministically Encoded CBOR as specified in {{Section 4.2 of CBOR}}, with map key ordering following the original specification in {{Section 3.9 of RFC7049}} for historical compatibility.
-
-The encoding rules described here are compatible with similar deterministic-CBOR profiles such as {{DRISL}}.
-
-The deterministic encoding rules that apply in this specification are:
-
-- Integers are encoded in their shortest form
-- All arrays, maps, and strings are encoded with explicit lengths; CBOR's indefinite-length encoding is not used
-- Floating-point values are not used; this includes NaN and infinity values
-- Map keys are sorted using the legacy length-first ordering of {{Section 3.9 of RFC7049}}
-- Maps MUST NOT contain duplicate keys
-
-For interoperability purposes, hash links between repository objects are encoded using a specific format within the CBOR structure. SHA-256 hash links are represented as CBOR byte strings under tag 42, with the byte string containing the 32-byte hash value prefixed by the fixed byte sequence `0x01711220`.
-
-Hash links that point to arbitrary binary data instead of other repository objects should be encoded similarly though prefixed by the fixed byte sequence `0x01551220`.
-
-The four prefix bytes encode (in order): a version byte `0x01`; a codec identifier byte (`0x71` for repository objects encoded with deterministic CBOR; `0x55` for arbitrary raw binary data); a hash-algorithm identifier byte `0x12` indicating SHA-256; and a hash-length byte `0x20` indicating 32 bytes. The 32-byte SHA-256 digest follows.
 
 # Repository Serialization Format {#serialization}
 
 Repositories are serialized for transmission and storage as a concatenated sequence of block data, where blocks represent the CBOR-encoded records, MST nodes, and commit objects that comprise the repository structure. The serialization is prefixed with a header that identifies the root block, typically the repository's commit object.
 
 Serialized repositories may contain partial repository state, such as when transmitting cryptographic proofs for specific records. In these situations, they may not include unrelated MST nodes or records outside the proof path.
+
+The block-and-header layout described here is compatible with Content-Addressable archive (CAR) formats such as {{DASL-CAR}}.
 
 ## Header Format {#serialization-header}
 
@@ -483,7 +394,7 @@ The CBOR-encoded header is prefixed with its byte length encoded as an unsigned 
 Following the header, each repository block is serialized by concatenating:
 
 1. The combined byte length of the following two components, encoded as an unsigned LEB128 integer
-2. The block's content hash, prefixed with `0x01711220` as specified in {{cbor}}
+2. The block's content hash, prefixed with `0x01711220` as specified in {{cbor-encoding}}
 3. The CBOR-encoded block data
 
 ~~~aasvg
@@ -496,15 +407,13 @@ Following the header, each repository block is serialized by concatenating:
 
 Producers SHOULD emit blocks in pre-order traversal of the included repository portion: header, commit object, root MST node, then a recursive depth-first interleaving of subtree nodes and the records they reference.
 
-Preorder traversal enables streaming verification of repositories, allowing parsers to walk the MST structure and output key-to-record mappings while maintaining minimal MST state in memory. This approach supports efficient processing of large repositories without requiring complete buffering of the serialized data.
+Preorder traversal enables streaming verification of repositories, allowing parsers to walk the MST structure and output key-to-record mappings while maintaining minimal MST state in memory. This approach supports efficient stream processing of large repositories without requiring complete buffering of the serialized data.
 
 Parsers MUST tolerate other block orderings, duplicate occurrences of the same block, and additional unrelated blocks. Specifically:
 
 - Duplicate blocks SHOULD be deduplicated rather than treated as an error.
 - Dangling references — for example, hash links pointing to records or blobs that are not present in the serialized data — MAY be present and unresolvable; this is not an error in itself.
 - Unrelated blocks not referenced by the repository structure SHOULD be ignored. Excessive quantities of such blocks MAY be treated as a form of resource abuse; see {{security}}.
-
-The block-and-header layout described here is compatible with content-addressable archive formats such as {{DASL-CAR}}.
 
 # Security Considerations {#security}
 
@@ -528,4 +437,111 @@ To mitigate these attacks, implementations should:
 
 When importing repositories, implementations should verify the completeness and integrity of the repository structure. Serialized repositories may contain additional unrelated blocks beyond those required for the repository structure. Care should be taken during storage to avoid resource waste on unreferenced blocks and to prevent potential storage exhaustion attacks.
 
+# IANA Considerations
+
+This document has no IANA actions.
+
 --- back
+
+# Data Model {#data-model}
+
+TODO: context about determinism and JSON/CBOR mapping (especially for record data)
+
+## Content Identifier (CID) Hashes {#cid-link}
+
+TODO: talk about string encoding and JSON encoding (in addition to bytes)
+
+For interoperability purposes, hash links between repository objects are encoded using a specific format within the CBOR structure. SHA-256 hash links are represented as CBOR byte strings under tag 42, with the byte string containing the 32-byte hash value prefixed by the fixed byte sequence `0x01711220`.
+
+Hash links that point to arbitrary binary data instead of other repository objects should be encoded similarly though prefixed by the fixed byte sequence `0x01551220`.
+
+The four prefix bytes encode (in order): a version byte `0x01`; a codec identifier byte (`0x71` for repository objects encoded with deterministic CBOR; `0x55` for arbitrary raw binary data); a hash-algorithm identifier byte `0x12` indicating SHA-256; and a hash-length byte `0x20` indicating 32 bytes. The 32-byte SHA-256 digest follows.
+
+## CBOR Encoding {#cbor-encoding}
+
+Repository content requires consistent binary representation across all implementations to ensure identical content hashes and verifiable integrity. All records, MST nodes, and commits must be encoded using Deterministically Encoded CBOR as specified in {{Section 4.2 of CBOR}}, with map key ordering following the original specification in {{Section 3.9 of RFC7049}} for historical compatibility.
+
+The deterministic encoding rules that apply in this specification are:
+
+- Integers are encoded in their shortest form
+- All arrays, maps, and strings are encoded with explicit lengths; CBOR's indefinite-length encoding is not used
+- Floating-point values are not used; this includes NaN and infinity values
+- Map keys are sorted using the legacy length-first ordering of {{Section 3.9 of RFC7049}}
+- Maps MUST NOT contain duplicate keys
+
+The encoding rules described here are compatible with similar deterministic-CBOR profiles such as {{DRISL}}.
+
+## JSON Encoding {#json-encoding}
+
+TODO: bytes (base64)
+TODO: cid-link
+
+# Cryptography {#crypto}
+
+AT implementations must support both of the following elliptic curves and signature algorithms:
+
+- NIST P-256 (also known as secp256r1 or p256) {{SEC2}}
+- secp256k1 (also known as k256) {{SEC2}}
+
+## Signature Malleability {#crypto-malleable}
+
+ECDSA signatures exhibit malleability, allowing transformation into distinct but equally valid signatures without access to the private key or original data. While the security impact is limited, signature malleability could enable broadcast of multiple valid versions of the same repository commit with different hashes, potentially causing consumer confusion.
+
+To prevent such scenarios, AT requires all ECDSA signatures to be canonicalized in low-S form. Specifically, the `s` component of the signature must satisfy `s ≤ n/2`, where `n` is the order of the curve's base point.
+
+## Signature Generation {#crypto-sig}
+
+To compute a signature over CBOR-encoded bytes in the context of AT:
+
+1. Compute the SHA-256 hash of the encoded bytes. Do not encode the resulting hash bytes.
+2. Sign the hash bytes using the current signing key associated with the account
+3. Format the signature bytes as a concatenation of the 32-byte `r` and 32-byte `s` values
+
+# Timestamp Identifier (TID) {#tid}
+
+Timestamped Identifiers (TIDs) are compact string encodings of 64-bit integers, which can be used as logical clocks or locally-unique sorted identifiers. They are not expected to be globally unique.
+
+They have the following structure:
+
+- 64-bit integer with big-endian byte ordering
+- Base32-sortable encoding using characters `234567abcdefghijklmnopqrstuvwxyz`
+- Fixed 13-character length with no padding (integer zero encodes as `2222222222222`)
+
+The layout of the 64-bit integer is:
+
+- The top bit is always 0
+- The next 53 bits represent microseconds since the UNIX epoch. 53 bits is chosen as the maximum safe integer precision in a 64-bit floating point number, as used by Javascript.
+- The final 10 bits are an arbitrary "clock identifier."
+
+When generating a sequence of TIDs in the same context (eg, for an individual account), care should be taken to ensure that the TID value always increments. If the system clock rolls backwards, or multiple TIDs are generated in the same microsecond, the microsecond component should be incremented past the previous generated value.
+
+# Namespaced Identifier (NSID) Syntax {#nsid}
+
+Collections are identified by a Namespaced Identifier (NSID): an ASCII string in reverse domain-name order followed by an additional name segment. The portion preceding the final segment is the **domain authority**; the final segment is the **name**.
+
+NSIDs MUST conform to the following syntax:
+
+- Overall:
+    - MUST contain only ASCII characters
+    - MUST separate the domain authority and the name by an ASCII period (`.`)
+    - MUST contain at least three segments
+    - MUST be at most 317 characters in total length
+- Domain authority:
+    - Composed of segments separated by ASCII periods (`.`)
+    - At most 253 characters in total (including periods), and at least two segments
+    - Each segment MUST contain at least 1 and at most 63 characters
+    - The allowed characters are ASCII letters (`A-Z`, `a-z`), digits (`0-9`), and hyphens (`-`)
+    - Segments MUST NOT start or end with a hyphen
+    - The first segment (the top-level domain) MUST NOT start with a digit
+    - The domain authority is not case-sensitive and SHOULD be normalized to lowercase
+- Name:
+    - MUST contain at least 1 and at most 63 characters
+    - The allowed characters are ASCII letters and digits only (`A-Z`, `a-z`, `0-9`)
+    - Hyphens are not allowed
+    - MUST NOT start with a digit
+    - Case-sensitive; implementations MUST NOT normalize case
+
+# Acknowledgments
+{:numbered="false"}
+
+TODO acknowledge.

--- a/draft-holmgren-at-repository.md
+++ b/draft-holmgren-at-repository.md
@@ -165,23 +165,23 @@ informative:
 
 --- abstract
 
-This document specifies the repository semantics for Authenticated Transfer (AT), a protocol for cryptographically-verifiable storage and distribution of structured user-controlled data. It defines the AT repository that serves as the fundamental data storage model.
-
-This document specifically deals with the repository structure and format. Overall network architecture is described further in {{AT-ARCH}}.
+This document specifies a repository data structure for storage and and transfer of public user data records as part of the Authenticated Transfer Protocol (ATP). It describes encoding formats for both individual data records and entire repositories. The repository data structure is content-addressable and cryptographically authenticated.
 
 --- middle
 
 # Introduction {#intro}
 
-The Authenticated Transfer (AT) repository addresses the challenges of building decentralized applications that require consistent data replication across distributed multi-party infrastructure. Traditional web platforms maintain user data at a single network location, creating vendor lock-in and limiting user agency over their digital identity and published content.
+The Authenticated Transfer Protocol (ATP) enables the creation of decentralized networks for publication of self-certifying data. An introduction to the overall protocol architecture is given in {{AT-ARCH}}.
 
-In the AT model, user data is stored in cryptographically signed repositories that can be hosted, synchronized, and distributed by any compatible server while preserving data authenticity and user ownership. Each repository consists of a set of CBOR-encoded objects called records, organized lexicographically by type. The cryptographic structure allows repository contents to be re-distributed and cached by any network participant without requiring trust in intermediary hosts.
+User accounts publish structured data records to the network by including them in their public repository. Records within a repository are identified by a unique path and current content version (hash). Records can be created, updated, and deleted at any time. Repositories contain the complete set of current records for the account, and does not include or reveal the existence of previous content.
 
-An AT repository provides a sorted key-value interface where values are CBOR-encoded objects referred to as records. Applications interact with repositories through standard CRUD operations while the underlying Merkle tree structure enables cryptographic verification of all modifications.
+The repository structure includes the account's persistent identifier, and the overall repository structure is cryptographically signed. The authenticitiy of the entire repository can be verified by resolving the account identifier to the current public key. Data records are not signed individually. Details of account identifier systems and their resolution process are out of scope for this document.
 
-Repository authority is established through Decentralized Identifiers (DIDs). Each repository is associated with exactly one DID, which resolves to the cryptographic key material necessary for verifying repositories.
+Large binary data such as images and media files are not stored directly within repositories. Instead, such data is stored externally and referenced in records by a hash link.
 
-This document describes version `3` of the AT repository format. Both previous versions are deprecated, and implementations do not need to support them.
+Mechanisms for synchronizing repositories between parties over the public network are described in {{AT-SYNC}}.
+
+This document describes version `3` of the repository format.
 
 # Repository Semantics {#repo-semantics}
 


### PR DESCRIPTION
This is on top of Danny's re-write branch.

Some of the bigger opinionated changes:

- try to talk about account identifier systems as little as possible here; there will be separate docs for that. Don't mention DIDs at all (though maybe we should at least mention that the `did` field in the commit object is for "historical reasons" or similar)
- move several chunks to appendixes: NSID, TID, Cryptography, CBOR encoding. these are chunks that we need to talk about somewhere (and this may end up being the best place) but aren't really the main focus of this document.
- talk a bit more about overall data model and record structure

I'm a little unsure about the purpose and content of the "Semantics" section, vs "Structure". This split seems somewhat common in docs like this, but sometimes it feels like pulling descriptive/"meaning" text away from the implementation details makes it harder to read/understand?

~I have a couple remaining TODOs in this branch.~