### PR TITLE
sync doc drafting

### DIFF
--- a/draft-holmgren-at-synchronization.md
+++ b/draft-holmgren-at-synchronization.md
@@ -66,154 +66,132 @@ informative:
 
 --- abstract
 
-This document specifies the synchronization protocol for Authenticated Transfer (AT), a protocol for cryptographically-verifiable storage and distribution of structured user-controlled data. It defines synchronization mechanisms that allow efficient distribution of repository changes to interested parties.
-
-This document builds on the AT repository format specified in {{ATREPO}}. Overall network architecture is described further in {{AT-ARCH}}.
+This document describes synchronization mechanisms for public repositories as part of the Authenticated Transfer Protocol (ATP). It specifies both a low-latency streaming protocol over WebSocket, and a full-repository fetch mechanism over HTTP.
 
 --- middle
 
 # Introduction {#intro}
 
-The Authenticated Transfer (AT) synchronization protocol addresses the challenges of building decentralized applications that require consistent data replication across distributed multi-party infrastructure. In the AT model, user data is stored in cryptographically signed repositories as specified in {{ATREPO}}. The synchronization system provides efficient mechanisms for propagating repository state changes across the network, supporting both real-time streaming updates and bulk synchronization scenarios. The protocol can detect dropped or withheld updates and provides cryptographic proofs for all operations, including record deletions, ensuring that consumers can maintain accurate and complete views of repository state.
+The Authenticated Transfer Protocol (ATP) enables the creation of decentralized networks for publication of self-certifying data. An introduction to the overall protocol architecture is given in {{AT-ARCH}}.
 
-The AT synchronization model operates on the principle that any participant can independently verify repository updates. This allows sync to occur between any client and server without requiring that the server is a canonical or trusted host.
+The protocol provides efficient synchronization mechanisms for propagating public repository state changes across the network, supporting both low-latency streaming updates and bulk synchronization scenarios. Synchronization can take place between any two parties, from an upstream publisher to a downstream consumer. Intermediate parties can redistribute ("relay") data, and consumers can cryptographically verify the integrity and authenticity of received repository data. This allows for flexibility in network topology to improve overall network relience and efficiency.
 
-AT supports multiple synchronization patterns: full repository synchronization for complete replicas, partial synchronization for specific record subsets, and proof-only synchronization for cryptographic verification without content retrieval.
+Repositories are complete (they contain all current public records for the account), and consumers can confirm the integrity over the entire repository to detect dropped or withheld updates. The protocol allows consumers to maintain partial replicas (eg, of only specific record types). It is also possible to request verifiable "inclusion proofs" for individual records on demand.
 
-The typical synchronization workflow establishes baseline state through full synchronization, then maintains currency through incremental updates. Full synchronization is performed by fetching a complete serialized repository over HTTPS, as specified in {{ATREPO}}.
+This document describes two synchronization mechanisms. Complete repositories can be serialized (as described in {{ATREPO}}) and fetched over HTTP as a snapshot. Updates to one or more repositories can be distributed as a stream of messages. This document describes both a generic structure and semantics for streaming messages, and a specific WebSocket transport and message encoding scheme.
 
-This document combines two transport modes. Real-time updates are delivered through a long-lived WebSocket {{RFC6455}} connection over which the producer streams binary event frames to the consumer. Full-state transfer is performed via HTTPS retrieval of a serialized repository as defined in {{ATREPO}}.
+# Account Hosting {#accounts}
 
-The event-stream model defined here — a sequence of typed frames carrying repository diffs and metadata — is the substantive content of the synchronization protocol. The WebSocket framing in {{realtime}} is the currently-deployed binding for that model. The same event-stream semantics could be defined over other transports without altering the validation and re-synchronization rules in this document.
+Each node in the network which synchronizes, stores, and distributes repository data maintains hosting status for each account. The status indicates whether the account is overall "active", or has been temporarily or permanently removed from the network, in which case repository data should not be synchronized further. Hosting status can be set by the account holder themselves or their canonical hosting provider, and changes propagate to downstream consumers throughout the network. Each downstream service or node in the network may set a local inactive hosting status, declining to distribute that account's repository data.
 
-# Relays {#relays}
+Each account has a persistent identifier which can be resolved to both a public key and a canonical hosting location. Account identifier systems and their resolution mechanisms are out of scope for this document. Account hosting status is maintained and transmitted over the synchronization protocol, separate from the lifecycle of account identifiers.
 
-The synchronization protocol is designed so that consumers do not need to obtain repository data directly from each repository's canonical host. Repository content is cryptographically signed by the account that owns it, allowing any third party to redistribute that content without compromising authenticity. This enables a class of intermediary services, called **relays**, that subscribe to upstream event streams and re-emit events to their own downstream consumers.
-
-A relay typically:
-
-- Subscribes to one or more upstream event streams from canonical hosts and/or other relays.
-- Optionally validates and filters incoming events according to its own policies.
-- Re-emits events to downstream consumers using the same protocol described in this document.
-- Serves or redirects requests for full-repository data ({{ATREPO}}) on behalf of accounts whose content it redistributes.
-
-Relays exist for a number of reasons, including: aggregating events from many canonical hosts into a single stream that downstream consumers can subscribe to once; offloading bandwidth and connection load from canonical hosts; and applying policy transformations such as filtering or moderation.
-
-Together, these capabilities allow a relay to fulfill the full synchronization contract — real-time event subscription and re-synchronization — for its downstream consumers, without those consumers needing to locate or contact the canonical host directly.
-
-A relay is just another producer from a downstream consumer's perspective. The consumer does not need to know whether its direct upstream is a canonical host or a relay; the validation rules in {{streaming-validation}} apply identically in either case.
-
-# Accounts {#accounts}
-
-Each service that participates in the synchronization protocol maintains an independent **hosting status** for every account whose content it redistributes.
-
-Account identifiers themselves, and the resolution of an identifier to its current signing key, are defined in {{ATREPO}}; this section is concerned with the hosting status that producers maintain about accounts they redistribute, not with identity resolution.
+The hosting status itself for accounts may always be redistributed, even for inactive accounts.
 
 ## Hosting Status {#account-status}
 
-An account is, at any point in time, either active or not — represented by an `active` boolean.
+Account hosting status at any point in time can be summarized as the boolean state of being "active" or not. If the account hosting status is not active, repository data for that account MUST NOT be redistributed. Additional context may be provided using a "status" vocabulary, represented as a string. Account status is represented and transmitted as an `active` boolean and a `status` string together.
 
-When `active` is false, an optional `status` string clarifies the reason. The known status values are:
+The defined status values and their meanings are:
 
-- `deleted`: the user or host has deleted the account. Content SHOULD be removed from the service's infrastructure. Implied to be permanent, but MAY be reverted.
-- `deactivated`: the user has temporarily paused the account. Content MUST NOT be redistributed but does not need to be deleted from infrastructure. Implied time-limited.
-- `takendown`: the host or service has taken down the account. Implied to be permanent or long-term, but MAY be reverted.
-- `suspended`: the host or service has temporarily paused the account. Implied time-limited.
+- `deleted` (`active` is false): the user or host has deleted the account. Account data SHOULD be removed from the service's infrastructure within a reasonable time frame. Implied to be permanent, but MAY be reverted.
+- `deactivated` (`active` is false): the user has temporarily paused the account. Account data MUST NOT be redistributed but does not need to be deleted from infrastructure. Implied time-limited.
+- `takendown` (`active` is false): the host or service has taken down the account. Implied to be indefinite in duration, but MAY be reverted.
+- `suspended` (`active` is false): the host or service has temporarily paused the account. Implied time-limited.
+
+Two additional status values are relevant the the synchronization process itself, and do not imply that the overall hosting status is inactive:
+
 - `desynchronized` (`active` MAY be true): the service has detected a problem synchronizing the account's repository and may be missing content.
 - `throttled` (`active` MAY be true): the service has paused processing of new content for this account because a rate limit has been exceeded.
 
-New status values MAY be defined in the future. Producers MAY emit `status` strings not listed above, and consumers MUST tolerate unrecognized values. Consumers SHOULD use the `active` boolean as the authoritative indicator of overall account visibility, treating the `status` string as clarification that may inform more specific behavior (for example, whether to delete cached data versus retain it pending reactivation).
+New status values may be defined in the future. Producers MAY emit `status` strings not listed above, and consumers MUST tolerate unrecognized values. Consumers MUST use the `active` boolean as the authoritative indicator of overall account visibility, treating the `status` string as clarification that may inform more specific behavior (for example, whether to delete cached data versus retain it pending reactivation).
 
-Producers expose an HTTPS request-response operation that, given an account identifier, returns the producer's current hosting status for that account. This allows consumers to query the present state of an account without subscribing to the event stream — for example, when establishing initial state for an account they have not seen before, or when reconciling diverging upstream reports.
+Producers expose an HTTPS request-response operation that, given an account identifier, returns the producer's current hosting status for that account. This allows consumers to query the present state of an account without subscribing to the message stream — for example, when establishing initial state for an account they have not seen before, or when reconciling diverging upstream reports.
 
-The wire-level details of the request, the URL path, and the response media type are not specified by this document. The currently-deployed binding is described separately.
+The details of the the HTTPS request endpoint, the URL path, and the response media type are not specified by this document.
 
-## Account Status Propagation {#account-status-propagation}
+## Status Propagation {#account-status-propagation}
 
-Account hosting status is not cryptographically authenticated. Status propagates hop-by-hop on the real-time event stream: each redistributing service emits an `#account` event ({{account-events}}) to its own downstream consumers when its local hosting status for an account changes.
+Account hosting status is not cryptographically authenticated. Status propagates hop-by-hop via streaming synchronization: each node emits an `#account` message ({{msg-account}}) to downstream consumers when the hosting status for an account changes. For intermediate synchronization nodes, this includes changes driven by an `#account` message received from an upstream.
 
-Intermediaries MAY override their upstream's status. For example, a relay may take down an account that an upstream still reports as active. Such overrides are propagated downstream as `#account` events from the intermediary.
+Intermediaries MAY override their upstream's status. For example, a relaying node may take down an account that an upstream still reports as active. Such overrides are propagated downstream as `#account` messages from the intermediary.
 
-When an upstream service is unreachable, downstream services SHOULD retain the previously reported status for some implementation-defined period rather than immediately changing the account to an inactive state. This preserves availability across short upstream outages.
+When an upstream service is unreachable, downstream services SHOULD retain the previously reported status for some implementation-defined period rather than immediately changing the account to an inactive state. This preserves availability across short upstream outages, and increases resiliency of the network.
 
-When account status reported by different upstreams diverges (for example, due to differing moderation policies, or a transient network partition between an upstream and its own upstream), services MUST apply their own policies to reconcile. Querying the account's current authoritative hosting service directly is one way to resolve such ambiguity.
+When account status reported by different upstreams diverges (for example, due to differing moderation policies, or a transient network partition between an upstream and its own upstream), services apply their own policies to reconcile. Querying the account's current authoritative hosting service directly is one way to resolve such ambiguity.
 
-# Full Repository Retrieval {#full-sync}
+# Full Repository Sync {#full-sync}
 
-A consumer establishes full synchronization by retrieving the complete state of a repository at a single point in time. This is the foundation for both initial synchronization and consumer re-synchronization ({{resync}}), and is also used by consumers that do not maintain a continuous subscription.
+Consumers can retrieve a full serialized snapshot of an account's current repository at any point in time. This can be used to initialize synchronization state for the account during a bootstrap or backfill phase, or to re-synchronize ({{resync}}) and reconcile after any disontinuity in the streaming synchronization mechanism. It is also an option for applications and use-cases which do not require continuous updates or synchronization over time.
 
-The retrieval is performed via HTTPS request to a producer's full-repository endpoint. Sync producers expose an operation that, given an account identifier, returns the current state of the named repository as a serialized stream conforming to {{ATREPO}}. The serialized stream's header points at the current commit; the stream contains the full repository graph reachable from that commit.
+Producers expose an HTTP API endpoint which takes an account identifier as a parameter, and returns the serialized repository as the response body. If the account hosting status at the producer is not "active", this is indicated in an error response.
 
-A producer MAY support additional request parameters that scope the response, including:
+A producer MAY redirect the request to another producer that holds the requested data — for example, a relaying service redirecting to the account's canonical host, or to a mirroring service with the content cached. Consumers SHOULD follow such HTTP redirects when re-synchronizing per {{resync}}.
 
-- A baseline revision, in which case the response is a diff representing the changes from that baseline to the current revision and follows the rules of {{diffs}}.
-- A subset of repository paths, in which case the response contains only the blocks required to verify those paths.
 
-A producer MAY redirect the request to another producer that holds the requested data — for example, a relay redirecting to the account's canonical host, or to a peer relay with the content cached. Consumers SHOULD follow such redirects when re-synchronizing per {{resync}}.
+# Streaming Sync {#stream-sync}
 
-# Repository Diffs {#diffs}
+This section describes a low-latency streaming synchronization mechanism which allows consumers to receive repository updates with minimal latency through a pull-based WebSocket {{RFC6455}} connection. Streams can contain updates from many distinct account repositories, even aggregating all updates in the network. In addition to repository updates, they include updates to account hosting status and network identities. Whether encompassing the full network or any subset of it, a stream is often referred to as a "firehose".
 
-A repository diff carries the data that changed between two repository revisions: the new commit, any new MST nodes, and any created or updated record blocks. Applying a diff to a known baseline reconstructs the complete repository state at the new revision. Diffs are used in two places in this protocol: as the response to a baselined full-repository retrieval ({{full-sync}}), and as the `blocks` payload of `#commit` events on the real-time stream ({{commit-events}}).
+To ensure reliable delivery, each message on a given stream is given a monotonically-increasing sequence number. Consumers can track their progress on processing messages and reconnect to the stream using the last-processed sequence number as a cursor value as needed. Producers can maintain a "backfill window" of recently transmitted messages. All consumers receive the same messages in the same order with the same sequence numbers.
 
-## Diff Format {#diff-format}
+The stream synchronization mechanism allows consumers to maintain complete indices of authenticated repository contents without needing to store complete copies of the repository MST structure. This significantly reduces storage overhead.
 
-Diffs use the same serialization format as complete repositories, with the commit block serving as the root. A diff MUST include:
+## Repository Diffs {#diffs}
+
+A repository diff carries the data that changed between two repository revisions: the new commit, any new MST nodes, and any created or updated record blocks. Applying a diff to a copy of the priority repository state results in the complete repository at the new revision. Repository diffs are used in the streaming synchronization mechanism.
+
+The commits within diffs are signed. Receiving parties can always verify those signatures, and the integrity of the blocks in the diff itself. But unless the receiving part has a full copy of the repository just prior to the diff, it can not verify the overall integrity of the diff or the final state of the repository. In particular, if record deletion operations were included in the diff, the receiving party can not enumerate or verify which records were impacted just from the diff.
+
+This section describes an "operation inversion" mechanism which allows receiving parties to verify the integrity of diffs when combined with metadata about the record-level operations encapsulated by the diff.
+
+### Diff Serialization Format {#diff-format}
+
+Diffs use the same serialization format as complete repositories (described in {{ATREPO}}), with the commit block serving as the root. A diff MUST include:
 
 - The new commit block.
 - All created and updated record blocks.
-- All MST nodes in the current repository that did not exist in the baseline revision.
+- All MST nodes in the current repository that did not exist in the prior revision.
 
-Required blocks MUST be included in the diff regardless of their presence in earlier repository history. For example, if an MST node was previously present in the repository, then deleted, and subsequently reintroduced during the range that the diff represents, the diff MUST include that block even though it appeared in prior revisions.
+Required blocks MUST be included in the diff regardless of their presence in earlier repository history. For example, if an MST node was previously present in the repository, then deleted, and subsequently reintroduced during the range that the diff represents, the diff MUST include that block.
 
-Deleted records and past versions of updated records are excluded from diffs.
+Deleted records and prior versions of updated records are excluded from diffs.
 
 With the exception of deleted record data, a diff MAY include additional blocks; receivers SHOULD ignore them.
 
-## Stateful Diff Verification {#diff-stateful-verify}
+### Operation Inversion {#operation-inversion}
 
-Consumers that maintain a complete current copy of a repository can verify a diff directly: each created or updated record's hash chain can be checked from the new commit through the MST to the leaf, and the consumer's own state provides any context needed to confirm that the operation list is exhaustive (for example, by enumerating which keys disappeared between the consumer's prior state and the new state).
-
-Stateless consumers — those that do not maintain a copy of the full repository — cannot enumerate deletions from the diff alone, since the diff does not contain the values of deleted records. For these consumers, the protocol provides operation inversion as a stateless verification mechanism.
-
-## Operation Inversion {#operation-inversion}
-
-In some cases, a diff is accompanied by an explicit operation list (`ops`) declaring the creates, updates, and deletes it represents. Operation inversion verifies that this declared list is accurate and exhaustive without requiring to any prior local state.
+A diff can accompanied by an explicit operation list declaring the record-level creates, updates, and deletes it represents, along with a claimed previous repository tree root hash. Operation inversion verifies that this declared list is accurate and complete.
 
 To invert a diff against its declared operations:
 
-1. Parse the diff's `blocks` as a partial MST per {{ATREPO}}.
-2. For each entry in `ops`, apply the inverse operation to the partial MST: `create` becomes `delete`, `delete` becomes `create`, and `update` reverts the value to the operation's `prev` field.
-3. Compute the root hash of the resulting MST.
-4. Compare the computed root hash to the previous root hash declared by the diff (the `prevData` field of a `#commit` event, or the equivalent baseline-revision root for diffs from {{full-sync}}).
+1. Extract the diff's MST nodes into a partial tree structure
+2. For each entry in the operation list, apply the inverse operation to the partial MST: each "create" becomes a "delete", "delete" becomes "create", and "update" reverts the record value to the previous version
+3. Compute the root hash of the resulting MST
+4. Compare the computed root hash to the claimed previous root hash
 
 If the hashes match, the operation list is accurate and exhaustive. If they differ, either the operation list is incomplete or the diff is internally inconsistent; in either case the diff MUST be rejected.
 
-Producers of diffs intended to support operation inversion MUST include, in addition to the blocks required by {{diff-format}}, the MST nodes for keys directly adjacent (in lexicographic order) to mutated keys. Without these adjacent nodes, the inverse operation cannot be correctly applied to the partial MST. Diffs carried in `#commit` events ({{commit-events}}) MUST satisfy this requirement, since stateless consumers rely on operation inversion for verification.
+Producers of diffs intended to support operation inversion MUST include, in addition to the blocks required by {{diff-format}}, the MST nodes for keys directly adjacent (in lexicographic order) to mutated keys. Without these adjacent nodes, the inverse operation cannot be correctly applied to the partial MST. Diffs carried in streaming synchronization messages ({{msg-commit}}) MUST satisfy this requirement, since stateless consumers rely on operation inversion for verification.
 
-# Real-time synchronization {#realtime}
+Receivers can track repository root hash values for each account and verify the claimed root hashes provided with the diff. This fixed-size state is significantly smaller than maintaining full repository data.
 
-AT supports real-time synchronization, enabling applications to receive repository updates with minimal latency through a pull-based WebSocket {{RFC6455}} connection.
+## WebSocket Transport {#websocket}
 
-Real-time streams of repository updates are often referred to as the “firehose”. The firehose delivers events containing repository diffs along with supporting metadata necessary for verification and processing.
+A consumer (client) establishes a WebSocket connection {{RFC6455}} to the producer's (server) stream endpoint. Secure WebSockets (using TLS) MUST be used for any internet-facing deployment.
 
-Each event includes a monotonic cursor that establishes a total ordering across all repository changes from a given host. This ordering enables reliable event replay and ensures that consumers can maintain consistent state even when reconnecting after network interruptions.
+Once the connection is established, the producer sends a sequence of binary WebSocket frames to the consumer. Each frame carries a single message. Servers SHOULD ignore stream messages sent by the consumer: the protocol defined in this document is server-to-client only.
 
-AT allows consumers to maintain fully-verified copies of repository records without storing the underlying Merkle tree structure, providing an efficient method for applications that need authenticated content access without the overhead of complete repository replication.
-
-## Wire Protocol {#wire}
-
-A consumer establishes a WebSocket connection {{RFC6455}} to the producer's stream endpoint. TLS MUST be used for any internet-facing deployment; cleartext WebSocket connections are intended only for local development.
-
-Once the connection is established, the producer sends a sequence of binary WebSocket frames to the consumer. Each frame carries an event. Servers SHOULD ignore any frames sent by the consumer; the stream defined in this document is server-to-client only.
+Servers and clients SHOULD implement a keepalive system using Ping and Pong WebSocket messages.
 
 ### Frame Format {#frame-format}
 
-Each binary frame contains two CBOR-encoded objects concatenated together: a header followed by a payload. Both objects MUST follow the deterministic CBOR encoding rules defined in {{ATREPO}}.
+Each binary WebSocket frame contains two CBOR-encoded objects concatenated together: a header followed by a payload. Both objects MUST follow the deterministic CBOR encoding rules defined in {{ATREPO}}.
 
 The header contains:
 
 - `op` (integer, REQUIRED): the frame operation. The value `1` indicates a normal message; the value `-1` indicates an error.
-- `t` (string, REQUIRED when `op = 1`): the message-type name, prefixed with `#`. For example, `#commit` for a commit event.
+- `t` (string, REQUIRED when `op = 1`): the message-type name, prefixed with `#`. For example, `#commit` for a commit message.
 
 The payload is a CBOR object whose schema is determined by the message type indicated in the header. Payloads are always CBOR objects, never arrays or scalars.
 
@@ -236,136 +214,145 @@ If the producer rejects the WebSocket upgrade request itself, it responds with a
 
 ## Cursors and Resumption {#cursors}
 
-Real-time synchronization streams include per-message cursors to improve transmission reliability. Cursors are positive integers that increase monotonically across the stream. Cursor semantics are flexible, and they may contain arbitrary gaps between consecutive messages.
+Synchronization streams include per-message sequence numbers to improve transmission reliability. Sequence numbers are positive integers that increase monotonically across the stream. Sequence semantics are flexible, and they may contain arbitrary gaps between consecutive messages.
 
-Consumers track the last cursor value they successfully processed and can specify this cursor when reconnecting to receive any missed messages within the provider's rollback window. Providers maintain no persistent consumer state across connections, relying entirely on the cursor values supplied by consumers during reconnection.
+Consumers track the last sequence number they successfully processed and can specify this as a cursor when reconnecting to receive any missed messages within the provider's backfill window. Consumers are responsible for managing and persisting cursor state themselves: producers do not maintain consumer-specific state across connections. The scope of a cursor is the (hostname, endpoint) pair: a cursor value is meaningful only when reconnecting to the same host and stream endpoint that issued it.
 
-The scope of a cursor is the (host, endpoint) pair: a cursor value is meaningful only when reconnecting to the same host and stream endpoint that issued it. Cursor values MUST NOT be re-used: if a producer must reset its cursor state for any reason, it MUST resume issuing cursors at a value greater than any value it has previously issued on that endpoint.
+Sequence numbers MUST NOT be repeated by producers on the same (hostname, endpoint) pair. If a producer must reset sequence numbers for any reason, it MUST start with a number higher than any previously broadcast.
 
-Cursor values are integers in the range `[1, 2^53)`. The upper bound is chosen so that cursors are exactly representable in 64-bit IEEE-754 floating point.
+Sequence numbers are integers in the range `[1, 2^53)`. The upper bound is chosen so that cursors are exactly representable in 64-bit IEEE-754 floating point.
 
 Stream behavior depends on the cursor value specified during connection:
 
 - **No cursor specified**: The provider begins transmitting from the current stream position, providing only new messages generated after the connection is established.
-- **Future cursor**: When the requested cursor exceeds the current stream cursor, the provider sends an error message and closes the connection.
-- **Cursor within rollback window**: The provider transmits all persisted messages with cursor numbers greater than or equal to the requested cursor, then continues with the real-time stream once caught up.
-- **Cursor older than rollback window**: The provider sends an informational message indicating that the requested cursor is too old, then begins transmission at the oldest available event, sends the entire rollback window, and continues with the real-time stream.
-- **Cursor value of 0**: The provider treats this as a request for the complete available history, starting at the oldest available event, transmitting the entire rollback window, then continuing with the real-time stream.
+- **Future cursor**: When the requested cursor exceeds the current stream sequence number, the provider sends an error message and closes the connection.
+- **Cursor within backfill window**: The provider transmits all persisted messages with sequence numbers numbers greater than or equal to the requested cursor, in order, then continues with the stream once caught up.
+- **Cursor older than backfill window**: The provider sends an informational message indicating that the requested cursor is too old, then begins transmission at the oldest available message, sends the entire backfill window, and continues with the stream.
+- **Cursor value of 0**: The provider treats this as a request for the complete available history, starting at the oldest available message, transmitting the entire backfill window, then continuing with the stream.
 
-## Event Types {#event-types}
+## Message Types {#msg-types}
 
-The real-time stream delivers four types of events: `#commit`, `#sync`, `#identity`, and `#account`.
+The repository synchronization stream uses four message types: `#commit`, `#sync`, `#account`, and `#identity`. This section describes the schema and semantics of these messages. Some fields are common across all message types.
 
-### Common Fields {#event-common}
+### Common Message Fields {#msg-common}
 
-The following fields are common to all event payloads:
+The following fields are common to all message payloads:
 
-- `seq` (integer, REQUIRED): the sequence number (cursor; see {{cursors}}) of this event.
-- `did` (string, REQUIRED): the account identifier of the repository this event concerns. For historical reasons the `#commit` event uses the field name `repo` rather than `did` for this purpose; the value has the same meaning.
-- `time` (string, REQUIRED): an ISO 8601 datetime string indicating when the event was emitted. This timestamp is informational and is not authoritative for any verification purpose.
+- `seq` (integer, REQUIRED): the sequence number (cursor; see {{cursors}}) of this message.
+- `did` (string, REQUIRED): the account identifier of the repository this message concerns. For historical reasons the `#commit` message uses the field name `repo` rather than `did` for this purpose; the value has the same meaning.
+- `time` (string, REQUIRED): an ISO 8601 datetime string indicating when the message was emitted. This timestamp is informational and is not authoritative for any verification purpose.
 
-### `#commit` Events {#commit-events}
+### `#commit` Message {#msg-commit}
 
-A `#commit` event represents an atomic set of repository modifications and consists of a repository diff combined with supporting metadata.
+A `#commit` message represents a repository update, as an atomic set of record operations. The mssage contains a repository diff combined with supporting metadata.
 
 The payload contains:
 
-- `seq` (integer, REQUIRED): see {{event-common}}.
-- `repo` (string, REQUIRED): the account identifier of the repository (see {{event-common}}; this is the historical name of the `did` field).
-- `time` (string, REQUIRED): see {{event-common}}.
-- `rev` (string, REQUIRED): the new revision identifier of the repository after these modifications.
-- `since` (string, REQUIRED, nullable): the revision identifier of the repository before these modifications. MAY be null only for the first commit of a repository.
-- `commit` (hash reference, REQUIRED): hash reference to the new commit object.
-- `blocks` (byte string, REQUIRED): the serialized diff (as defined in {{diffs}}) carrying all blocks required to verify the operations in this event.
-- `ops` (array, REQUIRED): an ordered list of repository operations represented by this event. Each entry is an object containing:
+- `seq` (integer, REQUIRED): see {{msg-common}}.
+- `repo` (string, REQUIRED): the account identifier of the repository (see {{msg-common}}; this is the historical name of the `did` field). MUST match the `did` field in the commit object enclosed in `blocks`.
+- `time` (string, REQUIRED): see {{msg-common}}.
+- `rev` (string, REQUIRED): the new revision identifier of the repository after these modifications. MUST match the `rev` field in the commit object enclosed in `blocks`.
+- `since` (string, REQUIRED, nullable): the revision identifier of the repository immediately prior to this commit. May be null only for the first commit of a repository.
+- `commit` (hash link, REQUIRED): reference to the new commit object. MUST match the hash of the commit object enclosed in `blocks`.
+- `blocks` (byte string, REQUIRED): the serialized diff (as defined in {{diffs}}) carrying all blocks required to invert and verify the operations in this message.
+- `ops` (array, REQUIRED): the set of record operations encapsulated by this message. Multiple operations on the same record (path) are not allowed within a commit. Each entry is an object containing:
     - `action` (string, REQUIRED): one of `create`, `update`, or `delete`.
-    - `path` (string, REQUIRED): the repository path being mutated.
+    - `path` (string, REQUIRED): the repository path of the record being mutated.
     - `cid` (hash reference, REQUIRED, nullable): the hash reference of the new record at this path, or `null` for `delete` actions.
     - `prev` (hash reference, OPTIONAL): the hash reference of the prior record at this path. Present for `update` and `delete` actions; absent for `create`.
-- `prevData` (hash reference, REQUIRED): the root hash of the repository's MST in the previous revision. Used for operation-inversion validation as described in {{streaming-validation}}.
+- `prevData` (hash reference, REQUIRED): the root hash of the repository's MST in the previous revision (the `data` field in the commit object). Used for operation-inversion validation as described in {{streaming-validation}}.
 - `tooBig` (boolean, REQUIRED): retained for compatibility with earlier versions of this protocol. Producers MUST emit this field with the value `false`. Consumers MUST ignore the field's value.
 - `blobs` (array, REQUIRED): retained for compatibility with earlier versions of this protocol. Producers MUST emit this field as an empty array. Consumers MUST ignore the field's contents.
 
-A `#commit` event MUST contain no more than 200 entries in `ops`. The `blocks` field MUST NOT exceed 2 MB. Any single record block within `blocks` MUST NOT exceed 1 MB. Mutations exceeding these limits MUST be communicated through `#sync` events instead.
+A `#commit` message MUST contain no more than 200 entries in `ops`. The `blocks` field MUST NOT exceed 2 MB. Any single record block within `blocks` MUST NOT exceed 1 MB. Repository updates exceeding these limits MUST be communicated through `#sync` message instead.
 
-A `#commit` event with an empty `ops` array (e.g., a commit issued solely to advance `rev` after a key rotation) is valid.
+A `#commit` message with an empty `ops` array (e.g., a commit issued solely to advance `rev` after a key rotation) is valid.
 
-### `#sync` Events {#sync-events}
+Note that the full message is not *not* cryptographically authenticated end-to-end (from the origin account itself). Only the commit object contained within the `blocks` field is signed, with other blocks covered by proof chains. The `ops` array is *not* authenticated and must be verified via operation inversion.
 
-A `#sync` event declares the current state of a repository, regardless of the previous state. Sync events are emitted when commit-event continuity cannot be maintained: large mutations exceeding the limits in {{commit-events}}, recovery from data loss or corruption, or account migration between hosting providers.
+### `#sync` Message {#msg-sync}
 
-The payload contains:
-
-- `seq` (integer, REQUIRED): see {{event-common}}.
-- `did` (string, REQUIRED): see {{event-common}}.
-- `time` (string, REQUIRED): see {{event-common}}.
-- `rev` (string, REQUIRED): the current revision identifier of the repository.
-- `blocks` (byte string, REQUIRED): a serialized stream containing the current commit object only. Receivers reconstruct full repository state by fetching the complete repository as described in {{resync}}.
-
-A `#sync` event provides a reset point that signals consumers to resynchronize against the current authoritative state without requiring knowledge of the intervening changes.
-
-### `#identity` Events {#identity-events}
-
-An `#identity` event indicates a possible change to the resolution result of an account identifier. Consumers SHOULD invalidate any cached identity metadata for the named account on receipt of this event and re-resolve the identifier.
+A `#sync` message declares the current state of a repository, regardless of the previous state. Sync messages are emitted when commit-message continuity cannot be maintained: large mutations exceeding the limits in {{msg-commit}}, recovery from data loss or corruption, or account migration between hosting providers.
 
 The payload contains:
 
-- `seq` (integer, REQUIRED): see {{event-common}}.
-- `did` (string, REQUIRED): see {{event-common}}.
-- `time` (string, REQUIRED): see {{event-common}}.
-- `handle` (string, OPTIONAL): the account's current handle, communicated non-authoritatively.
+- `seq` (integer, REQUIRED): see {{msg-common}}.
+- `did` (string, REQUIRED): see {{msg-common}}. MUST match the `did` field in the commit object encapsulated in `blocks`.
+- `time` (string, REQUIRED): see {{msg-common}}.
+- `rev` (string, REQUIRED): the current revision identifier of the repository. MUST match the `rev` field in the commit object encapsulated in `blocks`.
+- `blocks` (byte string, REQUIRED): a serialized stream containing only the current commit object. Receivers reconstruct full repository state by fetching the complete repository as described in {{resync}}.
 
-`#identity` events are best-effort: producers MAY emit them redundantly when no underlying change has occurred, and MAY fail to emit them when a change has occurred. Consumers SHOULD NOT rely on `#identity` events as the sole signal of identity change.
+A `#sync` message provides a reset point that signals consumers to resynchronize against the current authoritative state without requiring knowledge of the intervening changes.
 
-### `#account` Events {#account-events}
+A `#sync` message with a `rev` which is lower or equal to the previously tracked revision for an account would constitute a "rollback" and should be ignored. The commit object signature (within the `blocks` field) should also be verified, and the message rejected if validation fails.
 
-An `#account` event indicates a change in account hosting status at the emitting service.
+### `#account` Messages {#msg-account}
+
+An `#account` message indicates a change in account hosting status for an indicated account. See {{account-status}} for details and semantics.
 
 The payload contains:
 
-- `seq` (integer, REQUIRED): see {{event-common}}.
-- `did` (string, REQUIRED): see {{event-common}}.
-- `time` (string, REQUIRED): see {{event-common}}.
+- `seq` (integer, REQUIRED): see {{msg-common}}.
+- `did` (string, REQUIRED): see {{msg-common}}.
+- `time` (string, REQUIRED): see {{msg-common}}.
 - `active` (boolean, REQUIRED): whether the account is currently active on the emitting service.
-- `status` (string, OPTIONAL): a short status code describing the account state. See {{account-status}} for known values and semantics.
+- `status` (string, OPTIONAL): a short status code describing the account state.
+
+Note that account messages are *not* cryptographically authenticated end-to-end, and that they have hop-by-hop semantics.
+
+### `#identity` Message {#msg-identity}
+
+An `#identity` message indicates a possible change to the resolution result of an account identifier.
+
+Note that identity messages are *not* cryptographically authenticated end-to-end. Consumers SHOULD invalidate any cached identity metadata for the named account on receipt of this message, and then re-resolve the identifier.
+
+The payload contains:
+
+- `seq` (integer, REQUIRED): see {{msg-common}}.
+- `did` (string, REQUIRED): see {{msg-common}}.
+- `time` (string, REQUIRED): see {{msg-common}}.
+- `handle` (string, OPTIONAL): included for historical reasons. Non-authoritative.
+
+`#identity` messages are best-effort: producers MAY emit them redundantly when no underlying change has occurred, and MAY fail to emit them when a change has occurred. Consumers SHOULD NOT rely on `#identity` messages as the sole signal of identity change.
 
 ## Commit Validation {#streaming-validation}
 
-Validating a `#commit` event establishes both that the event is internally consistent (its declared operations match the diff it carries) and that the consumer can apply it to its existing state without missing intervening events.
+Validating a `#commit` message establishes both that the message is internally consistent (its declared operations match the diff it carries) and that matches the prior state of the account's repository from the perspective of the consumer.
 
-For each `#commit` event received, consumers MUST perform the following steps:
+For each `#commit` message received, consumers MUST perform the following steps:
 
-1. Verify wire-level fields: that the frame parses as deterministic CBOR, that the payload satisfies the schema in {{commit-events}}, and that the size limits in {{commit-events}} are not exceeded.
-2. Apply operation inversion to the event's `blocks` and `ops`, using the event's `prevData` as the expected previous root, per {{operation-inversion}}. If inversion fails, the event MUST be rejected.
-3. Verify the commit signature using the signing key resolved from the account identifier, as defined in {{ATREPO}}.
-4. Confirm that the event's `rev` is strictly greater than the previously observed `rev` for this account.
-5. Cross-check the event's `prevData` field against the consumer's locally tracked `data` for this account. If they differ, the consumer has become desynchronized for this account and MUST initiate re-synchronization as defined in {{resync}}.
+1. Verify wire-level fields: that the frame parses as deterministic CBOR, that the payload satisfies the schema in {{msg-commit}}, and that the size limits in {{msg-commit}} are not exceeded. Otherwise the message MUST be rejected.
+2. Parse the repository diff from `blocks`, verifying the deterministic CBOR encoding, schema, and syntax of all fields of the commit and MST nodes. All created and updated record blocks must be present, but the content and internal structure of records are not validated at this stage. If the repository diff is invalid, the message MUST be rejected.
+3. Apply operation inversion to the repository diff MST using the `ops` array, and match against the message's claimed `prevData`, as per {{operation-inversion}}. If inversion fails, the message MUST be rejected.
+4. Verify the commit signature using the signing key resolved from the account identifier. If the signature is invalid, the message MUST be rejected.
+5. Confirm that the message's `rev` is strictly greater than the previously observed `rev` for this account. Otherwise the message MUST be ignored.
+6. Cross-check the message's `prevData` field against the consumer's previously seen `data` for this account. If they differ, the consumer has become desynchronized for this account and MUST initiate re-synchronization as defined in {{resync}}.
 
-A signature failure at step 3 MAY indicate a recent key rotation rather than a malicious commit. Consumers SHOULD refresh the cached identity for the account once and re-attempt verification before treating the failure as a hard rejection.
+A signature failure at step 4 might indicate a recent key rotation rather than a malicious commit. Consumers SHOULD refresh the cached identity for the account and retry verification before rejecting the message.
 
 ## Re-synchronization {#resync}
 
-When a consumer detects desynchronization, either through a disjunction in commit history or a `sync` event that does not match their local state, they must perform a complete re-synchronization process to restore consistency with the current repository state.
+When a consumer detects desynchronization, either through a disjunction in commit history or a `sync` message that does not match their local state, they must perform a complete re-synchronization process to restore consistency with the current repository state.
 
-Re-synchronization requires fetching and processing the full repository structure, though the record contents themselves are optional depending on the consumer's needs. If the repository data is delivered in pre-order traversal, it can be validated incrementally as it streams in, producing a mapping of keys to record hashes that represents the complete repository state.
+Re-synchronization requires fetching and processing the full repository structure, though the record contents themselves are optional depending on the consumer's needs. If the repository data is delivered in pre-order traversal, it can be validated incrementally as it is received.
 
-This key-to-hash mapping can be compared against existing local state to identify discrepancies and verify the integrity of the re-synchronization. Once validated, this mapping establishes the new baseline state against which future commit events can be applied.
+Parsing the repository structure produces a mapping of keys (repository paths) to record versions (hashes) that represents the complete repository state. This key-to-hash mapping can be compared against existing local state to identify discrepancies and re-establish synchronization. Once validated, this mapping establishes the new repository state against which future commit messages can be applied.
 
-Consumers SHOULD prefer requesting full repository data from their direct upstream rather than the canonical host for the repository. Direct upstreams can coalesce or cache concurrent requests and redirect consumers to other sources where appropriate, reducing load on canonical hosts during correlated re-synchronization events.
+Consumers SHOULD prefer requesting full repository data from their direct upstream rather than the resolved canonical host for the repository. Direct upstreams MAY coalesce and cache snapshot requests, or redirect consumers to alternative sources where appropriate. This reduces correlated load spikes on canonical hosts caused by re-synchronization message broadcast.
 
-During the re-synchronization process, any incoming commit events for the repository should be buffered rather than processed immediately. Once re-synchronization completes successfully, these buffered commits can be validated and applied in sequence to bring the consumer fully up to date with the current repository state.
+During the re-synchronization process, any incoming commit messages for the repository should be buffered rather than processed immediately. Once re-synchronization completes successfully, these buffered commits can be validated and applied in sequence to bring the consumer fully up to date with the current repository state.
 
 # Security Considerations {#security}
 
-General security considerations for the repository format itself, including CBOR processing limits and MST structural validation, are covered in {{ATREPO}}.
+Security considerations for the repository format itself, including CBOR processing limits and MST structural validation, are covered in {{ATREPO}}.
 
 ## Resource Abuse {#security-resources}
 
-A producer that routinely emits sync events forces consumers into full re-synchronization, which is substantially more expensive than processing commit events. Similarly, a producer that rapidly updates the same key or issues many small commits can amplify event volume and bandwidth costs on downstream consumers. Consumers should apply rate limits and bandwidth budgets per repository, and may disconnect or deprioritize producers whose event patterns appear abusive.
+A producer that routinely emits `#sync` messages could cause consumers to repeated fetch full repository snapshots, which is substantially more expensive than processing `#commit` messages. Similarly, a producer that rapidly updates the same key or issues many small commits can amplify message volume and bandwidth costs on downstream consumers. Consumers should apply rate limits and bandwidth budgets per repository, and may disconnect or deprioritize producers whose message patterns appear abusive.
 
 ## Repository Rewinds {#security-rewinds}
 
-Intermediaries that relay firehose events can present a consumer with an outdated view of a repository by replaying older commits or declining to forward newer ones. The `rev` field on each commit can help consumers detect this: a received commit whose `rev` is not greater than the most recently observed `rev` for that repository may indicate that the producer is serving a rewound view. In situations such as this, consumers can cross-check the latest observed `rev` against the canonical host for the repository.
+Intermediaries that relay firehose messages can present a consumer with an outdated view of a repository by replaying older commits or declining to forward newer ones. The `rev` field on each commit can help consumers detect this: a received commit whose `rev` is not greater than the most recently observed `rev` for that repository may indicate that the producer is serving a rewound view. In situations such as this, consumers can cross-check the latest observed `rev` against the canonical host for the repository.
 
 ## Server-Side Request Forgery {#security-ssrf}
 
@@ -373,7 +360,7 @@ Several aspects of synchronization involve following URLs or host endpoints deri
 
 ## Validation Responsibility {#security-validation-responsibility}
 
-Intermediaries that relay events MAY apply some validation checks (for example, signature verification or size enforcement) before relaying. Consumers MUST NOT treat upstream relaying as evidence of validity: every consumer is ultimately responsible for performing the verification rules in {{streaming-validation}} on each event it processes.
+Intermediaries that relay messages MAY apply some validation checks (for example, signature verification or size enforcement) before relaying. Consumers MUST NOT treat upstream relaying as evidence of validity: every consumer is ultimately responsible for performing the verification rules in {{streaming-validation}} on each message it processes.
 
 # IANA Considerations
 

--- a/draft-holmgren-at-synchronization.md
+++ b/draft-holmgren-at-synchronization.md
@@ -1,5 +1,5 @@
 ---
-title: "Authenticated Transfer Synchronization"
+title: "Authenticated Transfer: Synchronization"
 abbrev: "AT Sync"
 category: std
 
@@ -11,10 +11,13 @@ date:
 consensus:
 v: 0
 area: "Applications and Real-Time Area"
-workgroup:
+workgroup: "Authenticated Transfer"
 keyword:
 venue:
-  github: "bluesky-social/ietf-drafts"
+  group: "Authenticated Transfer"
+  type: "Working Group"
+  mail: "atp@ietf.org"
+  github: "ietf-wg-atp/drafts"
 
 author:
  -
@@ -310,7 +313,7 @@ The payload contains:
 - `seq` (integer, REQUIRED): see {{event-common}}.
 - `did` (string, REQUIRED): see {{event-common}}.
 - `time` (string, REQUIRED): see {{event-common}}.
-- `handle` (string, OPTIONAL): the account's current handle, communicated non-authoritatively. 
+- `handle` (string, OPTIONAL): the account's current handle, communicated non-authoritatively.
 
 `#identity` events are best-effort: producers MAY emit them redundantly when no underlying change has occurred, and MAY fail to emit them when a change has occurred. Consumers SHOULD NOT rely on `#identity` events as the sole signal of identity change.
 
@@ -371,3 +374,14 @@ Several aspects of synchronization involve following URLs or host endpoints deri
 ## Validation Responsibility {#security-validation-responsibility}
 
 Intermediaries that relay events MAY apply some validation checks (for example, signature verification or size enforcement) before relaying. Consumers MUST NOT treat upstream relaying as evidence of validity: every consumer is ultimately responsible for performing the verification rules in {{streaming-validation}} on each event it processes.
+
+# IANA Considerations
+
+This document has no IANA actions.
+
+--- back
+
+# Acknowledgments
+{:numbered="false"}
+
+TODO: acknowledge

--- a/draft-holmgren-at-synchronization.md
+++ b/draft-holmgren-at-synchronization.md
@@ -249,9 +249,9 @@ The payload contains:
 - `ops` (array, REQUIRED): the set of record operations encapsulated by this message. Multiple operations on the same record (path) are not allowed within a commit. Each entry is an object containing:
     - `action` (string, REQUIRED): one of `create`, `update`, or `delete`.
     - `path` (string, REQUIRED): the repository path of the record being mutated.
-    - `cid` (hash reference, REQUIRED, nullable): the hash reference of the new record at this path, or `null` for `delete` actions.
-    - `prev` (hash reference, OPTIONAL): the hash reference of the prior record at this path. Present for `update` and `delete` actions; absent for `create`.
-- `prevData` (hash reference, REQUIRED): the root hash of the repository's MST in the previous revision (the `data` field in the commit object). Used for operation-inversion validation as described in {{streaming-validation}}.
+    - `cid` (hash link, REQUIRED, nullable): the hash link of the new record at this path, or `null` for `delete` actions.
+    - `prev` (hash link, OPTIONAL): the hash link of the prior record at this path. Present for `update` and `delete` actions; absent for `create`.
+- `prevData` (hash link, REQUIRED): the root hash of the repository's MST in the previous revision (the `data` field in the commit object). Used for operation-inversion validation as described in {{streaming-validation}}.
 - `tooBig` (boolean, REQUIRED): retained for compatibility with earlier versions of this protocol. Producers MUST emit this field with the value `false`. Consumers MUST ignore the field's value.
 - `blobs` (array, REQUIRED): retained for compatibility with earlier versions of this protocol. Producers MUST emit this field as an empty array. Consumers MUST ignore the field's contents.
 

--- a/draft-holmgren-at-synchronization.md
+++ b/draft-holmgren-at-synchronization.md
@@ -65,7 +65,7 @@ This document describes synchronization mechanisms for public repositories as pa
 
 The Authenticated Transfer Protocol (ATP) enables the creation of decentralized networks for publication of self-certifying data. An introduction to the overall protocol architecture is given in {{AT-ARCH}}.
 
-The protocol provides efficient synchronization mechanisms for propagating public repository state changes across the network, supporting both low-latency streaming updates and bulk synchronization scenarios. Synchronization can take place between any two parties, from an upstream publisher to a downstream consumer. Intermediate parties can redistribute ("relay") data, and consumers can cryptographically verify the integrity and authenticity of received repository data. This allows for flexibility in network topology to improve overall network relience and efficiency.
+The protocol provides efficient synchronization mechanisms for propagating public repository state changes across the network, supporting both low-latency streaming updates and bulk synchronization scenarios. Synchronization can take place between any two parties, from an upstream publisher to a downstream consumer. Intermediate parties can redistribute ("relay") data, and consumers can cryptographically verify the integrity and authenticity of received repository data. This allows for flexibility in network topology to improve overall network resilience and efficiency.
 
 Repositories are complete (they contain all current public records for the account), and consumers can confirm the integrity over the entire repository to detect dropped or withheld updates. The protocol allows consumers to maintain partial replicas (eg, of only specific record types). It is also possible to request verifiable "inclusion proofs" for individual records on demand.
 
@@ -90,7 +90,7 @@ The defined status values and their meanings are:
 - `takendown` (`active` is false): the host or service has taken down the account. Implied to be indefinite in duration, but MAY be reverted.
 - `suspended` (`active` is false): the host or service has temporarily paused the account. Implied time-limited.
 
-Two additional status values are relevant the the synchronization process itself, and do not imply that the overall hosting status is inactive:
+Two additional status values are relevant to the synchronization process itself, and do not imply that the overall hosting status is inactive:
 
 - `desynchronized` (`active` MAY be true): the service has detected a problem synchronizing the account's repository and may be missing content.
 - `throttled` (`active` MAY be true): the service has paused processing of new content for this account because a rate limit has been exceeded.
@@ -99,7 +99,7 @@ New status values may be defined in the future. Producers MAY emit `status` stri
 
 Producers expose an HTTPS request-response operation that, given an account identifier, returns the producer's current hosting status for that account. This allows consumers to query the present state of an account without subscribing to the message stream — for example, when establishing initial state for an account they have not seen before, or when reconciling diverging upstream reports.
 
-The details of the the HTTPS request endpoint, the URL path, and the response media type are not specified by this document.
+The details of the HTTPS request endpoint, the URL path, and the response media type are not specified by this document.
 
 ## Status Propagation {#account-status-propagation}
 
@@ -113,7 +113,7 @@ When account status reported by different upstreams diverges (for example, due t
 
 # Full Repository Sync {#full-sync}
 
-Consumers can retrieve a full serialized snapshot of an account's current repository at any point in time. This can be used to initialize synchronization state for the account during a bootstrap or backfill phase, or to re-synchronize ({{resync}}) and reconcile after any disontinuity in the streaming synchronization mechanism. It is also an option for applications and use-cases which do not require continuous updates or synchronization over time.
+Consumers can retrieve a full serialized snapshot of an account's current repository at any point in time. This can be used to initialize synchronization state for the account during a bootstrap or backfill phase, or to re-synchronize ({{resync}}) and reconcile after any discontinuity in the streaming synchronization mechanism. It is also an option for applications and use-cases which do not require continuous updates or synchronization over time.
 
 Producers expose an HTTP API endpoint which takes an account identifier as a parameter, and returns the serialized repository as the response body. If the account hosting status at the producer is not "active", this is indicated in an error response.
 
@@ -130,9 +130,9 @@ The stream synchronization mechanism allows consumers to maintain complete indic
 
 ## Repository Diffs {#diffs}
 
-A repository diff carries the data that changed between two repository revisions: the new commit, any new MST nodes, and any created or updated record blocks. Applying a diff to a copy of the priority repository state results in the complete repository at the new revision. Repository diffs are used in the streaming synchronization mechanism.
+A repository diff carries the data that changed between two repository revisions: the new commit, any new MST nodes, and any created or updated record blocks. Applying a diff to a copy of the prior repository state results in the complete repository at the new revision. Repository diffs are used in the streaming synchronization mechanism.
 
-The commits within diffs are signed. Receiving parties can always verify those signatures, and the integrity of the blocks in the diff itself. But unless the receiving part has a full copy of the repository just prior to the diff, it can not verify the overall integrity of the diff or the final state of the repository. In particular, if record deletion operations were included in the diff, the receiving party can not enumerate or verify which records were impacted just from the diff.
+The commits within diffs are signed. Receiving parties can always verify those signatures, and the integrity of the blocks in the diff itself. But unless the receiving party has a full copy of the repository just prior to the diff, it can not verify the overall integrity of the diff or the final state of the repository. In particular, if record deletion operations were included in the diff, the receiving party can not enumerate or verify which records were impacted just from the diff.
 
 This section describes an "operation inversion" mechanism which allows receiving parties to verify the integrity of diffs when combined with metadata about the record-level operations encapsulated by the diff.
 
@@ -152,7 +152,7 @@ With the exception of deleted record data, a diff MAY include additional blocks;
 
 ### Operation Inversion {#operation-inversion}
 
-A diff can accompanied by an explicit operation list declaring the record-level creates, updates, and deletes it represents, along with a claimed previous repository tree root hash. Operation inversion verifies that this declared list is accurate and complete.
+A diff can be accompanied by an explicit operation list declaring the record-level creates, updates, and deletes it represents, along with a claimed previous repository tree root hash. Operation inversion verifies that this declared list is accurate and complete.
 
 To invert a diff against its declared operations:
 
@@ -217,7 +217,7 @@ Stream behavior depends on the cursor value specified during connection:
 
 - **No cursor specified**: The provider begins transmitting from the current stream position, providing only new messages generated after the connection is established.
 - **Future cursor**: When the requested cursor exceeds the current stream sequence number, the provider sends an error message and closes the connection.
-- **Cursor within backfill window**: The provider transmits all persisted messages with sequence numbers numbers greater than or equal to the requested cursor, in order, then continues with the stream once caught up.
+- **Cursor within backfill window**: The provider transmits all persisted messages with sequence numbers greater than or equal to the requested cursor, in order, then continues with the stream once caught up.
 - **Cursor older than backfill window**: The provider sends an informational message indicating that the requested cursor is too old, then begins transmission at the oldest available message, sends the entire backfill window, and continues with the stream.
 - **Cursor value of 0**: The provider treats this as a request for the complete available history, starting at the oldest available message, transmitting the entire backfill window, then continuing with the stream.
 
@@ -235,7 +235,7 @@ The following fields are common to all message payloads:
 
 ### `#commit` Message {#msg-commit}
 
-A `#commit` message represents a repository update, as an atomic set of record operations. The mssage contains a repository diff combined with supporting metadata.
+A `#commit` message represents a repository update, as an atomic set of record operations. The message contains a repository diff combined with supporting metadata.
 
 The payload contains:
 
@@ -259,7 +259,7 @@ A `#commit` message MUST contain no more than 200 entries in `ops`. The `blocks`
 
 A `#commit` message with an empty `ops` array (e.g., a commit issued solely to advance `rev` after a key rotation) is valid.
 
-Note that the full message is not *not* cryptographically authenticated end-to-end (from the origin account itself). Only the commit object contained within the `blocks` field is signed, with other blocks covered by proof chains. The `ops` array is *not* authenticated and must be verified via operation inversion.
+Note that the full message is *not* cryptographically authenticated end-to-end (from the origin account itself). Only the commit object contained within the `blocks` field is signed, with other blocks covered by proof chains. The `ops` array is *not* authenticated and must be verified via operation inversion.
 
 ### `#sync` Message {#msg-sync}
 
@@ -308,7 +308,7 @@ The payload contains:
 
 ## Commit Validation {#streaming-validation}
 
-Validating a `#commit` message establishes both that the message is internally consistent (its declared operations match the diff it carries) and that matches the prior state of the account's repository from the perspective of the consumer.
+Validating a `#commit` message establishes both that the message is internally consistent (its declared operations match the diff it carries) and that it matches the prior state of the account's repository from the perspective of the consumer.
 
 For each `#commit` message received, consumers MUST perform the following steps:
 
@@ -339,7 +339,7 @@ Security considerations for the repository format itself, including CBOR process
 
 ## Resource Abuse {#security-resources}
 
-A producer that routinely emits `#sync` messages could cause consumers to repeated fetch full repository snapshots, which is substantially more expensive than processing `#commit` messages. Similarly, a producer that rapidly updates the same key or issues many small commits can amplify message volume and bandwidth costs on downstream consumers. Consumers should apply rate limits and bandwidth budgets per repository, and may disconnect or deprioritize producers whose message patterns appear abusive.
+A producer that routinely emits `#sync` messages could cause consumers to repeatedly fetch full repository snapshots, which is substantially more expensive than processing `#commit` messages. Similarly, a producer that rapidly updates the same key or issues many small commits can amplify message volume and bandwidth costs on downstream consumers. Consumers should apply rate limits and bandwidth budgets per repository, and may disconnect or deprioritize producers whose message patterns appear abusive.
 
 ## Repository Rewinds {#security-rewinds}
 

--- a/draft-holmgren-at-synchronization.md
+++ b/draft-holmgren-at-synchronization.md
@@ -43,15 +43,6 @@ normative:
         organization: Bluesky Social
 
 informative:
-  MST:
-    title: "Merkle Search Trees: Efficient State-Based CRDTs in Open Networks"
-    date: October 2019
-    target: https://inria.hal.science/hal-02303490/document
-    author:
-      -
-        fullname: Alex Auvolat
-      -
-        fullname: François Taïani
   AT-ARCH:
     title: "Authenticated Transfer: Architecture Overview"
     date: draft-newbold-at-architecture


### PR DESCRIPTION
Larger changes made here:

- removed mention of "diff since" functionality with the full repo fetch endpoint: I feel like this is pseudo-deprecated and not widely implemented
- removed mention of fetching subsets of full repos (aka, by collection): hasn't been implemented!
- renamed "real-time stream" to "low-latency stream"
- used "message" instead of "event" everywhere
- added a mention of websocket keepalive, which we don't actually have in the existing specs
- removed section about relay, though did mention intermediate services and "relaying services" a couple places
- used "sequence number" to talk about what is in the message and what producer emits, and "cursor" for what the consumer maintains and includes in requests

Some things we'll probably need to address in the future:

- should we include specific size limits here? should they be "MUST"? I think these should probably go in a BCP doc, not the (stable) standard
- clients "MUST" handle non-JSON or non-structured error messages for pre-upgrade HTTP errors: not sure this needs to be prescribed or a "MUST"? what is it that they "MUST" do there, not crash/halt?
- the `#sync` message section talks about using `#sync` to basically bypass diff size limits. I think we want to say those are just not allowed generally
- `time` field syntax needs to be described (datetime, that old can of worms)
- we don't get in to revision number semantics much here, feels like maybe we should? is covered a bit in the REPO draft
- do we need to mention the `#info` message type?
- mentioned "canonical host" a couple times; should we use PDS terminology, or something more consistent?
- can a message with seq number 0 be emitted? or should sequences start with 1 (or higher), and 0 is reserved as the semi-special "send me all you've got" cursor value?
- we don't talk about "requestCrawl" here at all. it is important on a pragmatic level, but maybe doesn't need to be be in this doc, could go in "operational BCP"